### PR TITLE
Read the production Solr URL from an environment variable; thanks Figs

### DIFF
--- a/config/solr.yml
+++ b/config/solr.yml
@@ -8,4 +8,4 @@ staging:
 cucumber:
   <<: *TEST
 production:
-  url: <%= (ENV[SOLR_URL] || 'http://solr.library.edu') %>
+  url: <%= (ENV['SOLR_URL'] || 'http://solr.library.edu') %>


### PR DESCRIPTION
@barnabyalter the comments on this config file mention something about pointing fedora.yml to the Solr URL but I couldn't figure out where to put it. Any help would be appreciated.
