### PR TITLE
Refactor the Rosie deploy task to set the variables before the tasks; us...

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -21,9 +21,23 @@ namespace :deploy do
   # end
 end
 
-set :rosie_endpoint_url, ENV['ICHABOD_ROSIE_ENDPOINT_URL']
-set :rosie_user, ENV['ICHABOD_ROSIE_USER']
-set :rosie_password, ENV['ICHABOD_ROSIE_PASSWORD']
+namespace :rosie do
+  # desc "Set variables for the Rosie the Riveter ingest tasks"
+  task :set_variables do
+    set :rosie_endpoint_url, ENV['ICHABOD_ROSIE_ENDPOINT_URL']
+    set :rosie_user, ENV['ICHABOD_ROSIE_USER']
+    set :rosie_password, ENV['ICHABOD_ROSIE_PASSWORD']
+  end
+  task :import do
+    set_variables
+    run "cd #{current_path}; bundle exec rake ichabod:load['rosie_the_riveter',#{rosie_endpoint_url},#{rosie_user},#{rosie_password}]"
+  end
+  task :delete do
+    set_variables
+    run "cd #{current_path}; bundle exec rake ichabod:delete['rosie_the_riveter',#{rosie_endpoint_url},#{rosie_user},#{rosie_password}]"
+  end
+end
+
 namespace :ingest do
   task :load_sdr do
     run "cd #{current_path}; bundle exec rake ichabod:load['spatial_data_repository','./ingest/sdr.xml']"
@@ -31,17 +45,11 @@ namespace :ingest do
   task :load_fda do
     run "cd #{current_path}; bundle exec rake ichabod:load['faculty_digital_archive','./ingest/stern.xml']"
   end
-  task :load_rosie do
-    run "cd #{current_path}; bundle exec rake ichabod:load['rosie_the_riveter',#{rosie_endpoint_url},#{rosie_user},#{rosie_password}]"
-  end
   task :delete_sdr do
     run "cd #{current_path}; bundle exec rake ichabod:delete[''spatial_data_repository',./ingest/sdr.xml']"
   end
   task :delete_fda do
     run "cd #{current_path}; bundle exec rake ichabod:delete['faculty_digital_archive''./ingest/stern.xml']"
-  end
-  task :delete_rosie do
-    run "cd #{current_path}; bundle exec rake ichabod:delete['rosie_the_riveter',#{rosie_endpoint_url},#{rosie_user},#{rosie_password}]"
   end
 end
 


### PR DESCRIPTION
Refactor the Rosie deploy task to set the variables before the tasks; use the name :import since :load is reserved for something else though I'm not sure why the namespace doesn't handle that
