### PR TITLE
clean database before FactoryGirl.lint

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,12 +63,18 @@ RSpec.configure do |config|
   config.filter_run_excluding half_baked: true
 
   config.before(:suite) do
-    # Run factory girl lint before the suite
-    FactoryGirl.lint
     # Startout by trucating all the tables
     DatabaseCleaner.clean_with :truncation
     # Then use transactions to roll back other changes
     DatabaseCleaner.strategy = :transaction
+
+    # Run factory girl lint before the suite
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
We were experiencing intermittent FactoryGirl.lint failures which appeared to
have been caused by the database not being fully cleaned between test suite
executions.

Moved database clean operation before FactoryGirl.lint and followed ThoughtBot
recommendation to wrap FactoryGirl.lint in a begin/ensure/end block.

References:
https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md
http://devblog.avdi.org/2012/08/31/configuring-database_cleaner-with-rails-rspec-capybara-and-selenium/
