### PR TITLE
update database.yml for Jenkins local database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,10 @@ mysql2: &mysql2
 
 remote: &remote
   <<: *mysql2
-  host:     <%= (ENV['ICHABOD_DB_HOST']     || 'localhost') %>
+  host: <%= (ENV['ICHABOD_DB_HOST'] || 'localhost') %>
   database: <%= (ENV['ICHABOD_DB_DATABASE'] || 'ichabod_test') %>
-  username: <%= (ENV['ICHABOD_DB_USER']     || ENV['JENKINS_DB_USER'] || 'root') %>
-  password: <%= (ENV['ICHABOD_DB_PASSWORD'] || ENV['JENKINS_DB_PASSWORD']) %>
+  username: <%= (ENV['ICHABOD_DB_USER'] || 'root') %>
+  password: <%= ENV['ICHABOD_DB_PASSWORD'] %>
 
 local: &local
   <<: *remote
@@ -19,7 +19,9 @@ staging:
   <<: *remote
 
 test: &test
-  <<: *local
+  <<: *remote
+  username: <%= (ENV['ICHABOD_DB_USER']     || ENV['JENKINS_DB_USER'] || 'root') %>
+  password: <%= (ENV['ICHABOD_DB_PASSWORD'] || ENV['JENKINS_DB_PASSWORD']) %>
 
 cucumber:
   <<: *test


### PR DESCRIPTION
@NYULibraries/hydra 
This PR adds Jenkins-specific environment variables `JENKINS_DB_*` to config/database.yml so
that Jenkins can execute the test suite using its own (local) MySQL
instance instead of relying on a remote MySQL database.
