### PR TITLE
Move jetty-related tasks to deploy/staging.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -76,7 +76,4 @@ namespace :jetty do
   end
 end
 
-before "deploy", "jetty:stop"
-after "deploy", "deploy:create_jetty_symlink", "jetty:start"
-
 # after "deploy", "deploy:create_symlink", "deploy:create_current_path_symlink", "deploy:create_env_symlink"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,2 +1,6 @@
 set :rails_env, "staging"
 set(:branch, ENV["GIT_BRANCH"].gsub(/remotes\//,"").gsub(/origin\//,""))
+
+before "deploy", "jetty:stop"
+after "deploy", "deploy:create_jetty_symlink", "jetty:start"
+


### PR DESCRIPTION
Reason for PR:
We use jetty in staging, but tomcat in production. Jetty-related tasks
need to be constrained to the staging environment.  In this commit,
the jetty-related before/after callbacks are relocated from deploy.rb
to deploy/staging.rb

[Finishes #73890674]
