### PR TITLE
Stab in the dark to see if poltergeist works on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
 
 before_script:
   # Load up X browser for selenium tests
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - mysql -e 'create database ichabod_test;'
   - RAILS_ENV=test bundle exec rake db:schema:load
   - bundle exec rails g hydra:jetty

--- a/features/support/local_env.rb
+++ b/features/support/local_env.rb
@@ -8,7 +8,7 @@ end
 
 require 'capybara/poltergeist'
 
-if ENV['IN_BROWSER'] || ENV['TRAVIS']
+if ENV['IN_BROWSER']
   # On demand: non-headless tests via Selenium/WebDriver
   # To run the scenarios in browser (default: Firefox), use the following command line:
   # IN_BROWSER=true bundle exec cucumber


### PR DESCRIPTION
@NYULibraries/hydra When initially setting up this project we couldn't get the cucumber tests to run headlessly on Travis. But since we're no longer using VCR which caused complications and all our dependencies are up to date Poltergeist now seems to pass without a problem on Travis. This solves our issue of failed cukes due to Selenium screen size/responsive design stuff.
