### PR TITLE
remove duplicated code, clean up one comment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -89,22 +89,6 @@ namespace :archive_it_accw do
   end
 end
 
-namespace :archive_it_accw do
-  # desc "Set variables for the Archive It Archive of Contemporary Composers' Websites ingest tasks"
-  task :set_variables do
-    set :archive_it_accw_endpoint_url, ENV['ICHABOD_ARCHIVE_IT_ACCW_ENDPOINT_URL']
-
-  end
-  task :import do
-    set_variables
-    run "cd #{current_path}; RAILS_ENV=#{rails_env} bundle exec rake ichabod:load['archive_it_accw',#{archive_it_accw_endpoint_url}]"
-  end
-  task :delete do
-    set_variables
-    run "cd #{current_path}; RAILS_ENV=#{rails_env} bundle exec rake ichabod:delete['archive_it_accw',#{archive_it_accw_endpoint_url}]"
-  end
-end
-
 namespace :ingest do
   task :load_sdr do
     run "cd #{current_path}; RAILS_ENV=#{rails_env} bundle exec rake ichabod:load['spatial_data_repository','./ingest/sdr.xml']"

--- a/lib/ichabod/resource_set/source_readers/archive_it_accw_reader.rb
+++ b/lib/ichabod/resource_set/source_readers/archive_it_accw_reader.rb
@@ -9,7 +9,7 @@ module Ichabod
       # Available via: the ArchiveIt JSON API
       #
       # The ArchiveIt API is not officially supported by the Internet Archive
-      # (who run ArchiveIt, and therefore we're reverse engineering the API
+      # (who run ArchiveIt), and therefore we're reverse engineering the API
       # with the knowledge that the API may change, or may not be supported at
       # all in the future.
       #


### PR DESCRIPTION
Highlights:
- removed duplicated code in `deploy.rb` that was discovered during code review
- cleaned up one comment in `archive_it_accw_reader.rb` file

Fixes #100 
