### PR TITLE
temporarily disable ArchiveItAccw functionality

### DIFF
--- a/features/collection_facet.feature
+++ b/features/collection_facet.feature
@@ -31,7 +31,8 @@ Feature: Collection facet
     When I filter my search to "Asian NGOs Reports" under the "Collection" category
     Then I should see search results
 
-  Scenario: Filter by Archive of Contemporary Composers Websites
-    Given I am on the default search page
-    When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
-    Then I should see search results
+  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
+  # Scenario: Filter by Archive of Contemporary Composers Websites
+  #   Given I am on the default search page
+  #   When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
+  #   Then I should see search results

--- a/features/collection_facet.feature
+++ b/features/collection_facet.feature
@@ -31,8 +31,8 @@ Feature: Collection facet
     When I filter my search to "Asian NGOs Reports" under the "Collection" category
     Then I should see search results
 
-  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
-  # Scenario: Filter by Archive of Contemporary Composers Websites
-  #   Given I am on the default search page
-  #   When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
-  #   Then I should see search results
+  @wip
+  Scenario: Filter by Archive of Contemporary Composers Websites 
+    Given I am on the default search page
+    When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
+    Then I should see search results

--- a/features/edit_metadata_authorization.feature
+++ b/features/edit_metadata_authorization.feature
@@ -20,19 +20,20 @@ Feature: Permission to edit metadata only to authorized users
     And I view record with id "sdr:DSS-NYCDCP_Mappluto_Test_11v1-DSS-jam_mappluto_7OR"
     Then the record should not have link "Edit"
 
-  @loggedin
-  Scenario: Edit option is available to AFC group for ArchiveIt ACCW records
-    Given I am logged in as an admin
-    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-    Then the record should have link "Edit"
+  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
+  # # @loggedin
+  # # Scenario: Edit option is available to AFC group for ArchiveIt ACCW records
+  # #   Given I am logged in as an admin
+  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+  # #   Then the record should have link "Edit"
 
-  @loggedin
-  Scenario: Edit option is not available to GIS Cataloger for ArchiveIt ACCW records
-    Given I am logged in as "GIS Cataloger"
-    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-    Then the record should not have link "Edit"
+  # # @loggedin
+  # # Scenario: Edit option is not available to GIS Cataloger for ArchiveIt ACCW records
+  # #   Given I am logged in as "GIS Cataloger"
+  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+  # #   Then the record should not have link "Edit"
 
-  Scenario: Edit option is not available to an unauthenticated user for ArchiveIt ACCW records
-    Given I am not logged in
-    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-    Then the record should not have link "Edit"
+  # # Scenario: Edit option is not available to an unauthenticated user for ArchiveIt ACCW records
+  # #   Given I am not logged in
+  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+  # #   Then the record should not have link "Edit"

--- a/features/edit_metadata_authorization.feature
+++ b/features/edit_metadata_authorization.feature
@@ -20,20 +20,20 @@ Feature: Permission to edit metadata only to authorized users
     And I view record with id "sdr:DSS-NYCDCP_Mappluto_Test_11v1-DSS-jam_mappluto_7OR"
     Then the record should not have link "Edit"
 
-  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
-  # # @loggedin
-  # # Scenario: Edit option is available to AFC group for ArchiveIt ACCW records
-  # #   Given I am logged in as an admin
-  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-  # #   Then the record should have link "Edit"
+  @loggedin @wip
+  Scenario: Edit option is available to AFC group for ArchiveIt ACCW records
+    Given I am logged in as an admin
+    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+    Then the record should have link "Edit"
 
-  # # @loggedin
-  # # Scenario: Edit option is not available to GIS Cataloger for ArchiveIt ACCW records
-  # #   Given I am logged in as "GIS Cataloger"
-  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-  # #   Then the record should not have link "Edit"
+  @loggedin @wip
+  Scenario: Edit option is not available to GIS Cataloger for ArchiveIt ACCW records
+    Given I am logged in as "GIS Cataloger"
+    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+    Then the record should not have link "Edit"
 
-  # # Scenario: Edit option is not available to an unauthenticated user for ArchiveIt ACCW records
-  # #   Given I am not logged in
-  # #   And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
-  # #   Then the record should not have link "Edit"
+  @wip
+  Scenario: Edit option is not available to an unauthenticated user for ArchiveIt ACCW records
+    Given I am not logged in
+    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+    Then the record should not have link "Edit"

--- a/features/search.feature
+++ b/features/search.feature
@@ -55,9 +55,9 @@ Feature: Perform a basic search
     And I limit my results to "Technical Report" under the "Format" category
     Then I should see search results
 
-  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
-  # Scenario: Search for Archive of Contemporary Composers Websites title
-  #   Given I am on the default search page
-  #   When I search on the phrase "louiskarchin.com"
-  #   Then I should see search results
+  @wip
+  Scenario: Search for Archive of Contemporary Composers Websites title
+    Given I am on the default search page
+    When I search on the phrase "louiskarchin.com"
+    Then I should see search results
 

--- a/features/search.feature
+++ b/features/search.feature
@@ -55,8 +55,9 @@ Feature: Perform a basic search
     And I limit my results to "Technical Report" under the "Format" category
     Then I should see search results
 
-  Scenario: Search for Archive of Contemporary Composers Websites title
-    Given I am on the default search page
-    When I search on the phrase "louiskarchin.com"
-    Then I should see search results
+  # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
+  # Scenario: Search for Archive of Contemporary Composers Websites title
+  #   Given I am on the default search page
+  #   When I search on the phrase "louiskarchin.com"
+  #   Then I should see search results
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -30,7 +30,10 @@ if Rails.env.cucumber?
     Ichabod::DataLoader.new('faculty_digital_archive_ngo','https://archive.nyu.edu/request','hdl_2451_33605',5).load
     # Loaded the voice collection up to record a cassette, but don't need it after that
     # Ichabod::DataLoader.new('voice', ENV['ICHABOD_VOICE_ENDPOINT_URL']).load
-    Ichabod::DataLoader.new('archive_it_accw','https://archive-it.org').load
+
+    # FIXME: @jgpawletko restore after ArchiveIt cassettes in place
+    # Ichabod::DataLoader.new('archive_it_accw','https://archive-it.org').load
+
     # Loaded the NYUPress collection up to record a cassette, but don't need it after that
     Ichabod::DataLoader.new('nyu_press_open_access_book', 'http://discovery.dlib.nyu.edu:8080/solr3_discovery/nyupress/select','0','5').load
 


### PR DESCRIPTION
@NYULibraries/hydra 
I created this PR so that it could be merged in the event that 
the [Internet Archive sites are down](https://twitter.com/internetarchive/status/543072665380999169)  for an extended period of time.

----

##### Background
The ArchiveItAccw collection data is loaded directly from the Archive It 
website: https://archive-it.org.  Due to a massive power outage in
San Francisco on 2014-12-11, the Internet Archive sites, including
Archive It, went offline.  This outage breaks the ArchiveItAccw data
loading step in the Ichabod cucumber setup.

This branch temporarily disables all ArchiveItAccw functionality until
the Internet Archive websites are back up and a cassette can be
recorded for ArchiveItAccw cucumber scenarios.

Highlights:
* disable ArchiveItAccw data loading in `feature/support/env.rb` 
* disable ArchiveItAccw scenarios