### PR TITLE
Bug/fix nyupress delete task

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -88,7 +88,7 @@ namespace :nyupress do
   end
   task :delete do
     set_variables
-    run "cd #{current_path}; RAILS_ENV=#{rails_env} bundle exec rake ichabod:delete['nyu_press_open_access_book',#{nyupress_endpoint_url}#{nyupress_endpoint_start},#{nyupress_endpoint_rows}]"
+    run "cd #{current_path}; RAILS_ENV=#{rails_env} bundle exec rake ichabod:delete['nyu_press_open_access_book',#{nyupress_endpoint_url},#{nyupress_endpoint_start},#{nyupress_endpoint_rows}]"
   end
 end
 

--- a/features/destroy_button_on_results.feature
+++ b/features/destroy_button_on_results.feature
@@ -16,8 +16,8 @@ Feature: Delete button on the main and detailed search results pages
  @loggedin
   Scenario: authorized user can delete record from the details display page and return to search results
     Given I am logged in as an admin
-    And "12" records with title "The Play" exists
-    And I search for "The Play"
+    And "12" records with title "Einen einzigen Wert" exists
+    And I search for "Einen einzigen Wert"
     And I navigate to the page "2" of the search results
     And I navigate to details display of the last result
     And I click on the first "Delete" link

--- a/features/edit_metadata_authorization.feature
+++ b/features/edit_metadata_authorization.feature
@@ -23,7 +23,7 @@ Feature: Permission to edit metadata only to authorized users
   @loggedin
   Scenario: Edit option is available to AFC group for ArchiveIt ACCW records
     Given I am logged in as "AFC Group"
-    And I view record with id "ai-accw:261ca521648b64ea12e077a254b58553"
+    And I view record with id "ai-accw:761d07efc02f1e39a27fb241aad46689"
     Then the record should have link "Edit"
 
   @loggedin


### PR DESCRIPTION
NYU Press Open Access Books delete job wasn't passing. Added comma to task to fix typo