### PR TITLE
Feature/add access restriction field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,6 +71,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('desc_metadata__lc_callnum', :stored_searchable, type: :string), :label => 'Call number'
     #NYUCore Additions
     config.add_index_field solr_name('desc_metadata__publisher', :stored_searchable, type: :string), :label => 'Publisher'
+    config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
     config.add_index_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,
                                                                                                     :text          => 'resource_text_display'
@@ -100,7 +101,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('desc_metadata__description', :stored_searchable, type: :string), :label => 'Description'
     config.add_show_field solr_name('desc_metadata__series', :stored_searchable, type: :string), :label => 'Series'
     config.add_show_field solr_name('desc_metadata__version', :stored_searchable, type: :string), :label => 'Also available as'
-
+    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
 
     config.add_show_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,8 +71,9 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('desc_metadata__lc_callnum', :stored_searchable, type: :string), :label => 'Call number'
     #NYUCore Additions
     config.add_index_field solr_name('desc_metadata__publisher', :stored_searchable, type: :string), :label => 'Publisher'
-    config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
-                                                                                                        :helper_method => :render_restrictions_text
+    config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
+    #config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
+                                                                                                      #  :helper_method => :render_restrictions_text
     config.add_index_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,
                                                                                                     :text          => 'resource_text_display'
@@ -102,8 +103,8 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('desc_metadata__description', :stored_searchable, type: :string), :label => 'Description'
     config.add_show_field solr_name('desc_metadata__series', :stored_searchable, type: :string), :label => 'Series'
     config.add_show_field solr_name('desc_metadata__version', :stored_searchable, type: :string), :label => 'Also available as'
-    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
-                                                                                                        :helper_method => :render_restrictions_text
+    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'#,
+                                                                                                        #:helper_method => :render_restrictions_text
 
     config.add_show_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,8 +72,6 @@ class CatalogController < ApplicationController
     #NYUCore Additions
     config.add_index_field solr_name('desc_metadata__publisher', :stored_searchable, type: :string), :label => 'Publisher'
     config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
-    #config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
-                                                                                                      #  :helper_method => :render_restrictions_text
     config.add_index_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,
                                                                                                     :text          => 'resource_text_display'
@@ -103,9 +101,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('desc_metadata__description', :stored_searchable, type: :string), :label => 'Description'
     config.add_show_field solr_name('desc_metadata__series', :stored_searchable, type: :string), :label => 'Series'
     config.add_show_field solr_name('desc_metadata__version', :stored_searchable, type: :string), :label => 'Also available as'
-    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'#,
-                                                                                                        #:helper_method => :render_restrictions_text
-
+    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
     config.add_show_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,
                                                                                                     :text          => 'resource_text_display'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,7 +71,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('desc_metadata__lc_callnum', :stored_searchable, type: :string), :label => 'Call number'
     #NYUCore Additions
     config.add_index_field solr_name('desc_metadata__publisher', :stored_searchable, type: :string), :label => 'Publisher'
-    config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
+    config.add_index_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
+                                                                                                        :helper_method => :render_restrictions_text
     config.add_index_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,
                                                                                                     :text          => 'resource_text_display'
@@ -101,7 +102,8 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('desc_metadata__description', :stored_searchable, type: :string), :label => 'Description'
     config.add_show_field solr_name('desc_metadata__series', :stored_searchable, type: :string), :label => 'Series'
     config.add_show_field solr_name('desc_metadata__version', :stored_searchable, type: :string), :label => 'Also available as'
-    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions'
+    config.add_show_field solr_name('desc_metadata__restrictions', :stored_searchable, type: :string), :label => 'Access Restrictions',
+                                                                                                        :helper_method => :render_restrictions_text
 
     config.add_show_field solr_name('desc_metadata__available', :stored_searchable, type: :string), :label => 'Online Resource',
                                                                                                     :helper_method => :render_external_links,

--- a/app/controllers/nyucores_controller.rb
+++ b/app/controllers/nyucores_controller.rb
@@ -62,7 +62,7 @@ class NyucoresController < ApplicationController
 
   # Whitelist attrs
   def item_params
-    params.require(:nyucore).permit(:identifier, title: [], creator: [], publisher: [], type: [], available: [], description: [], edition: [], series: [], version: [], date: [], format: [], language: [], relation: [], rights: [], subject: [], citation: [])
+    params.require(:nyucore).permit(:identifier, :restrictions, title: [], creator: [], publisher: [], type: [], available: [], description: [], edition: [], series: [], version: [], date: [], format: [], language: [], relation: [], rights: [], subject: [], citation: [])
   end
 
   def ensure_default_editors
@@ -110,4 +110,5 @@ class NyucoresController < ApplicationController
         true
     end
   end
+  binding.pry
 end

--- a/app/controllers/nyucores_controller.rb
+++ b/app/controllers/nyucores_controller.rb
@@ -110,5 +110,4 @@ class NyucoresController < ApplicationController
         true
     end
   end
-  binding.pry
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -18,16 +18,4 @@ module CatalogHelper
       nil
     end
   end
-
-  #converts stored restriction value into display friendly text
-  def render_restrictions_text(args)
-    document = args[:document]
-    field_name = args[:field]
-    begin
-      stored_value = document[field_name][0]
-      display_text = t('restrictions.type.'"#{stored_value}")   
-    rescue ArgumentError => e
-      nil
-    end
-  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -18,4 +18,16 @@ module CatalogHelper
       nil
     end
   end
+
+  #converts stored restriction value into display friendly text
+  def render_restrictions_text(args)
+    document = args[:document]
+    field_name = args[:field]
+    begin
+      stored_value = document[field_name][0]
+      display_text = t('restrictions.type.'"#{stored_value}")   
+    rescue ArgumentError => e
+      nil
+    end
+  end
 end

--- a/app/models/nyucore.rb
+++ b/app/models/nyucore.rb
@@ -1,6 +1,5 @@
 class Nyucore < ActiveFedora::Base
   include Hydra::AccessControls::Permissions
-
   NYUCORE_FIELDS = {
     :multiple => [:available, :citation, :title, :creator, :type, :publisher,
                   :description, :edition, :date, :format, :language, :relation,

--- a/app/models/nyucore.rb
+++ b/app/models/nyucore.rb
@@ -5,7 +5,7 @@ class Nyucore < ActiveFedora::Base
     :multiple => [:available, :citation, :title, :creator, :type, :publisher,
                   :description, :edition, :date, :format, :language, :relation,
                   :rights, :subject, :series, :version],
-    :single => [:identifier]
+    :single => [:identifier, :restrictions]
   }
   EXTRA_SINGLES = [:resource_set]
   EXTRA_MULTIPLES = [:addinfolink, :addinfotext]

--- a/app/resource_sets/spatial_data_repository.rb
+++ b/app/resource_sets/spatial_data_repository.rb
@@ -2,7 +2,7 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
   self.prefix = 'sdr'
   self.source_reader = :oai_dc_file_reader
   editor :gis_cataloger
-  before_load :add_additional_info_link, :add_access_rights
+  before_load :add_additional_info_link, :set_restriction_nyu_only
 
   attr_reader :filename
 
@@ -20,7 +20,6 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
 
   def add_access_rights(*args)
     nyucore = args.last
-    # hack to use controlled vocabulary only.
-    nyucore.source_metadata.restrictions = I18n.t('restrictions.type.nyu_only') 
+    nyucore.source_metadata.restrictions = nyucore.source_metadata.restrictions[0]
   end
 end

--- a/app/resource_sets/spatial_data_repository.rb
+++ b/app/resource_sets/spatial_data_repository.rb
@@ -20,6 +20,7 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
 
   def add_access_rights(*args)
     nyucore = args.last
+    # hack to use controlled vocabulary only.
     nyucore.source_metadata.restrictions = I18n.t('restrictions.type.nyu_only') 
   end
 end

--- a/app/resource_sets/spatial_data_repository.rb
+++ b/app/resource_sets/spatial_data_repository.rb
@@ -2,7 +2,8 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
   self.prefix = 'sdr'
   self.source_reader = :oai_dc_file_reader
   editor :gis_cataloger
-  before_load :add_additional_info_link, :set_restriction_nyu_only
+  set_restriction :nyu_only
+  before_load :add_additional_info_link
 
   attr_reader :filename
 
@@ -16,10 +17,5 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
     nyucore = args.last
     nyucore.source_metadata.addinfolink = 'http://nyu.libguides.com/content.php?pid=169769&sid=1489817'
     nyucore.source_metadata.addinfotext = 'GIS Dataset Instructions'
-  end
-
-  def add_access_rights(*args)
-    nyucore = args.last
-    nyucore.source_metadata.restrictions = nyucore.source_metadata.restrictions[0]
   end
 end

--- a/app/resource_sets/spatial_data_repository.rb
+++ b/app/resource_sets/spatial_data_repository.rb
@@ -20,6 +20,6 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
 
   def add_access_rights(*args)
     nyucore = args.last
-    nyucore.source_metadata.restrictions = "nyu_only"
+    nyucore.source_metadata.restrictions = I18n.t('restrictions.type.nyu_only') 
   end
 end

--- a/app/resource_sets/spatial_data_repository.rb
+++ b/app/resource_sets/spatial_data_repository.rb
@@ -2,7 +2,7 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
   self.prefix = 'sdr'
   self.source_reader = :oai_dc_file_reader
   editor :gis_cataloger
-  before_load :add_additional_info_link
+  before_load :add_additional_info_link, :add_access_rights
 
   attr_reader :filename
 
@@ -16,5 +16,10 @@ class SpatialDataRepository < Ichabod::ResourceSet::Base
     nyucore = args.last
     nyucore.source_metadata.addinfolink = 'http://nyu.libguides.com/content.php?pid=169769&sid=1489817'
     nyucore.source_metadata.addinfotext = 'GIS Dataset Instructions'
+  end
+
+  def add_access_rights(*args)
+    nyucore = args.last
+    nyucore.source_metadata.restrictions = "nyu_only"
   end
 end

--- a/config/access_rights.yml
+++ b/config/access_rights.yml
@@ -1,0 +1,3 @@
+type: 
+  nyu_only: "NYU Only"
+  authorized_only: "Restricted to Authorized Users"

--- a/config/access_rights.yml
+++ b/config/access_rights.yml
@@ -1,3 +1,4 @@
 type: 
   nyu_only: "NYU Only"
   authorized_only: "Restricted to Authorized Users"
+  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,3 @@ en:
   catalog:
     urls:
       geospatial_dataset_link_text: Download
-  restrictions: 
-    type:
-      nyu_only: "NYU Only"
-      authorized_only: "Restricted to Authorized Users"
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,8 @@ en:
   catalog:
     urls:
       geospatial_dataset_link_text: Download
+  restrictions: 
+    type:
+      nyu_only: "NYU Only"
+      authorized_only: "Restricted to Authorized Users"
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,4 @@ en:
   catalog:
     urls:
       geospatial_dataset_link_text: Download
+      

--- a/features/display.feature
+++ b/features/display.feature
@@ -1,7 +1,8 @@
-Feature: Click "Download" link for Geospatial dataset
-  In order to download a Geospatial dataset
+Feature: Geospatial dataset's various display tests
+  In order to use a Geospatial dataset
   As an on-campus NYU patron
   Once I’ve found a dataset in Ichabod, I need to be able to click on a download link
+  Once I've found a geospatial dataset, I would like to know my access restrictions
 
   Scenario: Display "Online Resource" field in search results
     Given I am on the default search page
@@ -25,3 +26,15 @@ Feature: Click "Download" link for Geospatial dataset
     And I search for "MapPLUTO"
     When I navigate to details display of the first result
     Then I should see the link "GIS Dataset Instructions" in the "Additional Information:" field
+ 
+  Scenario: Display "Access restrictions" field in search results
+    Given I am on the default search page
+    When I perform an empty search
+    And I limit my results to "Geospatial Data" under the "Format" category
+    Then I should get "Access Restrictions" field and its corresponding value "NYU Only" in all results
+    
+ Scenario: Display "Access restrictions" field in the details display
+    Given I limit my search to "Geospatial Data" under the "Format" category
+    And I search for "LION"
+    When I navigate to details display of the first result
+    Then I should see the value "NYU Only" in the "Access Restrictions:" field

--- a/features/step_definitions/display_steps.rb
+++ b/features/step_definitions/display_steps.rb
@@ -6,6 +6,12 @@ Then(/^I should get "(.*?)" field in all results$/) do |field|
   expect(documents_list_container.all('dt', :text => field)).to have_exactly(10).items
 end
 
+Then(/^I should get "(.*?)" field and its corresponding value "(.*?)" in all results$/) do |field,value|
+  expect(documents_list_container.all('dt', :text => field)).to have_exactly(10).items
+  expect(documents_list_container.all('dd', :text => value)).to have_exactly(10).items
+ 
+end
+
 And(/^I navigate to details display of the first result$/) do
   within(documents_list_container) do
     find(".document:first-child h5.index_title a").click
@@ -21,5 +27,5 @@ Then(/^I should see the link "(.*?)" in the "(.*?)" field$/) do |link, field|
 end
 
 Then(/^I should see the value "(.*?)" in the "(.*?)" field$/) do |value, field|
-  expect(document_field_value(field)).to have_content(value)
+    expect(document_field_value(field)).to have_content(value)
 end

--- a/lib/ichabod/resource_set/base.rb
+++ b/lib/ichabod/resource_set/base.rb
@@ -107,7 +107,7 @@ module Ichabod
       editor :admin_group
 
       # Default to adding the edit groups on create
-      before_load :add_edit_groups, :apply_restrictions
+      before_load :add_edit_groups
 
       # Default to adding the ResourceSet on create
       before_load :add_resource_set
@@ -136,6 +136,10 @@ module Ichabod
           nyucore = resource.to_nyucore
           before_load_methods.each do |before_load_method|
             before_load_method.call(resource, nyucore)
+          end
+          # if restrictions are specified, run the subroutine
+          unless (@set_restrictions.nil? || @set_restrictions.empty?)
+            apply_restrictions(nyucore)
           end
           if nyucore.save
             Rails.logger.info("#{nyucore.pid} has been saved to Fedora")

--- a/lib/ichabod/resource_set/base.rb
+++ b/lib/ichabod/resource_set/base.rb
@@ -145,6 +145,15 @@ module Ichabod
         end
       end
 
+      def set_restriction_nyu_only(*args)
+        nyucore = args.last
+        nyucore.source_metadata.restrictions = "boop"
+      end
+
+      def set_restriction_authorized_only(*args)
+        nyucore = args.last
+        nyucore.source_metadata.restrictions = "shoop"
+      end
       private
       def add_edit_groups(*args)
         nyucore = args.last

--- a/lib/ichabod/resource_set/base.rb
+++ b/lib/ichabod/resource_set/base.rb
@@ -147,14 +147,34 @@ module Ichabod
 
       def set_restriction_nyu_only(*args)
         nyucore = args.last
-        nyucore.source_metadata.restrictions = "boop"
+        restrict_hsh = add_restrictions
+        nyucore.source_metadata.restrictions = restrict_hsh[:nyu_only]
       end
 
       def set_restriction_authorized_only(*args)
         nyucore = args.last
-        nyucore.source_metadata.restrictions = "shoop"
+        restrict_hsh = add_restrictions
+        nyucore.source_metadata.restrictions = restrict_hsh[:authorized_only]
       end
+
       private
+      def add_restrictions
+        filename = 'config/access_rights.yml'
+        file = File.join(Rails.root, filename)
+
+        unless File.exists?(file)
+          raise "You are missing an access rights configuration file: #{filename}."
+        end
+
+        begin
+          yml = YAML.load_file(file)
+        rescue
+          raise("#{filename} was found, but could not be parsed.\n")
+        end
+
+        yml["type"].symbolize_keys
+      end
+
       def add_edit_groups(*args)
         nyucore = args.last
         nyucore.set_edit_groups(editors, []) unless editors.empty?

--- a/lib/nyucore_metadata/vocabulary.rb
+++ b/lib/nyucore_metadata/vocabulary.rb
@@ -1,7 +1,7 @@
 module NyucoreMetadata
   class Vocabulary < RDF::Vocabulary
     URI = 'http://harper.bobst.nyu.edu/data/nyucore#'
-    TERMS = [:available, :edition, :series, :version, :citation]
+    TERMS = [:available, :edition, :series, :version, :citation, :restrictions]
 
     TERMS.each { |term| property term }
 

--- a/spec/factories/nyucores.rb
+++ b/spec/factories/nyucores.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
     addinfotext ["Ask a Librarian"]
     addinfolink ["http://library.nyu.edu/ask"]
     resource_set 'resource_set'
+    restrictions 'NYU Only'
     after(:build) { |record| record.set_edit_groups(['admin_group'],[]) }
 
     factory :gis_record do

--- a/spec/ichabod/nyucore_datastream_spec.rb
+++ b/spec/ichabod/nyucore_datastream_spec.rb
@@ -20,7 +20,7 @@ module Ichabod
         subject { terms[NyucoreMetadata::Vocabulary] }
         it { should be_an Array }
         it do
-          should eq [:available, :edition, :series, :version, :citation]
+          should eq [:available, :edition, :series, :version, :citation, :restrictions]
         end
       end
       describe 'Ichabod::Vocabulary' do

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -5,6 +5,7 @@ module Ichabod
       let(:before_loads) { [:method1, :method2] }
       let!(:original_before_loads) { Base.before_loads - before_loads }
       let(:set_restrictions) { [:nyu_only, :authorized_only] }
+      let(:invalid_set_restrictions) { [:only_nyu] }
       let!(:original_set_restrictions) { Base.set_restrictions - set_restrictions }
       let(:editors) { [:editor1, :editor2] }
       let!(:original_editors) { Base.editors - editors }
@@ -147,6 +148,12 @@ module Ichabod
           it { should be_an Array }
           it { should eq set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s)) }
         end
+        context 'when configured with a value other than what is allowed for set_restrictions' do
+          before { Base.set_restriction(*invalid_set_restrictions) }
+          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+          it { should be_an Array }
+          it { should_not include set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s)) }
+        end
       end
       describe '#before_loads' do
         subject { base.before_loads }
@@ -205,7 +212,7 @@ module Ichabod
          context 'when there are no restrictions' do
           before { base.delete }
           before { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
-          it 'should return an array of Nyucores with no edit groups' do
+          it 'should return an array of Nyucores with no restrictions' do
             subject.each do |nyucore|
               expect(nyucore.restrictions).to be_nil
             end
@@ -231,7 +238,7 @@ module Ichabod
           its(:size) { should eq 5 }
           it 'should return an array of Nyucores with the specified value' do
             subject.each do |nyucore|
-              expect(nyucore.restrictions).to eq set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s))
+              expect(nyucore.restrictions).to eq "NYU Only"
             end
           end
         end

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -4,6 +4,8 @@ module Ichabod
     describe Base do
       let(:before_loads) { [:method1, :method2] }
       let!(:original_before_loads) { Base.before_loads - before_loads }
+      let(:set_restrictions) { [:nyu_only, :authorized_only] }
+      let!(:original_set_restrictions) { Base.set_restrictions - set_restrictions }
       let(:editors) { [:editor1, :editor2] }
       let!(:original_editors) { Base.editors - editors }
       let(:prefix) { 'mock' }
@@ -27,6 +29,17 @@ module Ichabod
         it 'should set the editors attribute on the class' do
           subject
           expect(Base.editors).to eq editors.unshift(*original_editors)
+        end
+      end
+      describe '.set_restriction' do
+        after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+        subject { Base.set_restriction(*set_restrictions) }
+        it 'should not raise an ArgumentError' do
+          expect { subject }.not_to raise_error
+        end
+        it 'should set the set_restrictions attribute on the class' do
+          subject
+          expect(Base.set_restrictions).to eq set_restrictions.unshift(*original_set_restrictions)
         end
       end
       describe '.before_load' do
@@ -122,6 +135,19 @@ module Ichabod
           it { should eq editors.map(&:to_s).unshift(*original_editors.map(&:to_s)) }
         end
       end
+      describe '#set_restrictions' do
+        subject { base.set_restrictions }
+        context 'when not configured with set_restrictions' do
+          it { should be_an Array }
+          it { should eq original_set_restrictions.map(&:to_s) }
+        end
+        context 'when configured with set_restrictions' do
+          before { Base.set_restriction(*set_restrictions) }
+          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+          it { should be_an Array }
+          it { should eq set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s)) }
+        end
+      end
       describe '#before_loads' do
         subject { base.before_loads }
         context 'when not configured with before loads' do
@@ -176,6 +202,15 @@ module Ichabod
             end
           end
         end
+         context 'when there are no restrictions' do
+          before { base.delete }
+          before { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+          it 'should return an array of Nyucores with no edit groups' do
+            subject.each do |nyucore|
+              expect(nyucore.restrictions).to be_nil
+            end
+          end
+        end
         context 'when there are editors', vcr: {cassette_name: 'resource sets/load resource set with editors'} do
           before { Base.editor(*editors) }
           after { Base.instance_variable_set(:@editors, original_editors)}
@@ -185,6 +220,18 @@ module Ichabod
           it 'should return an array of Nyucores with the specified edit groups' do
             subject.each do |nyucore|
               expect(nyucore.edit_groups).to eq editors.map(&:to_s).unshift(*original_editors.map(&:to_s))
+            end
+          end
+        end
+        context 'when there are restrictions', vcr: {cassette_name: 'resource sets/load resource set with restrictions'} do
+          before { Base.set_restriction(*set_restrictions) }
+          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+          it { should be_an Array }
+          it { should_not be_empty }
+          its(:size) { should eq 5 }
+          it 'should return an array of Nyucores with the specified value' do
+            subject.each do |nyucore|
+              expect(nyucore.restrictions).to eq set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s))
             end
           end
         end

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -4,9 +4,10 @@ module Ichabod
     describe Base do
       let(:before_loads) { [:method1, :method2] }
       let!(:original_before_loads) { Base.before_loads - before_loads }
-      let(:set_restrictions) { [:nyu_only, :authorized_only] }
+      let(:set_restrictions) { [:nyu_only] }
+      let(:all_restrictions) { [:nyu_only, :authorized_only] }
       let(:invalid_set_restrictions) { [:only_nyu] }
-      let!(:original_set_restrictions) { Base.set_restrictions - set_restrictions }
+      let!(:original_set_restrictions) { [] }
       let(:editors) { [:editor1, :editor2] }
       let!(:original_editors) { Base.editors - editors }
       let(:prefix) { 'mock' }
@@ -139,20 +140,20 @@ module Ichabod
       describe '#set_restrictions' do
         subject { base.set_restrictions }
         context 'when not configured with set_restrictions' do
-          it { should be_an Array }
-          it { should eq original_set_restrictions.map(&:to_s) }
+          it { should be_a String }
+          it { should eq original_set_restrictions.join("") }
         end
         context 'when configured with set_restrictions' do
           before { Base.set_restriction(*set_restrictions) }
           after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
-          it { should be_an Array }
-          it { should eq set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s)) }
+          it { should be_a String }
+          it { should eq set_restrictions.join("") }
         end
         context 'when configured with a value other than what is allowed for set_restrictions' do
           before { Base.set_restriction(*invalid_set_restrictions) }
           after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
-          it { should be_an Array }
-          it { should_not include set_restrictions.map(&:to_s).unshift(*original_set_restrictions.map(&:to_s)) }
+          it { should be_a String }
+          it { should_not include all_restrictions.map(&:to_s).join("")  }
         end
       end
       describe '#before_loads' do

--- a/spec/models/nyucore_spec.rb
+++ b/spec/models/nyucore_spec.rb
@@ -8,7 +8,7 @@ describe Nyucore do
     it { should have_key :single }
     it { should have_key :multiple }
     it 'should have the appropriate single fields' do
-      expect(subject[:single]).to eq [:identifier]
+      expect(subject[:single]).to eq [:identifier, :restrictions]
     end
     it 'should have the appropriate multiple fields' do
       expect(subject[:multiple]).to eq [:available, :citation, :title, :creator,
@@ -62,6 +62,8 @@ describe Nyucore do
     it { should be_valid }
     # Generic test for presence
     its(field) { should be_present }
+
+
 
     # Test the attribute writers
     describe "##{field}=" do

--- a/spec/nyucore_metadata/vocabulary_spec.rb
+++ b/spec/nyucore_metadata/vocabulary_spec.rb
@@ -9,7 +9,7 @@ module NyucoreMetadata
     describe Vocabulary::TERMS do
       subject { Vocabulary::TERMS }
       it { should be_an Array }
-      it { should eq [:available, :edition, :series, :version, :citation] }
+      it { should eq [:available, :edition, :series, :version, :citation, :restrictions] }
     end
 
     # Some metaprogramming to check that the terms are set appropriately

--- a/spec/resource_sets/spatial_data_repository_spec.rb
+++ b/spec/resource_sets/spatial_data_repository_spec.rb
@@ -7,7 +7,8 @@ describe SpatialDataRepository do
   it { should be_a Ichabod::ResourceSet::Base }
   its(:filename) { should eq filename }
   its(:editors) { should eq ['admin_group', 'gis_cataloger'] }
-  its(:before_loads) { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link] }
+  its(:before_loads) { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link, :add_access_rights] }
+
   describe '.prefix' do
     subject { SpatialDataRepository.prefix }
     it { should eq prefix }
@@ -22,6 +23,6 @@ describe SpatialDataRepository do
   end
   describe '.before_loads' do
     subject { SpatialDataRepository.before_loads }
-    it { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link] }
+    it { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link, :add_access_rights] }
   end
 end

--- a/spec/resource_sets/spatial_data_repository_spec.rb
+++ b/spec/resource_sets/spatial_data_repository_spec.rb
@@ -5,9 +5,10 @@ describe SpatialDataRepository do
   subject { SpatialDataRepository.new(filename) }
   it { should be_a SpatialDataRepository }
   it { should be_a Ichabod::ResourceSet::Base }
+  its(:set_restrictions) { should eq ['nyu_only'] }
   its(:filename) { should eq filename }
   its(:editors) { should eq ['admin_group', 'gis_cataloger'] }
-  its(:before_loads) { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link, :add_access_rights] }
+  its(:before_loads) { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link] }
 
   describe '.prefix' do
     subject { SpatialDataRepository.prefix }
@@ -21,8 +22,12 @@ describe SpatialDataRepository do
     subject { SpatialDataRepository.editors }
     it { should eq [:admin_group, :gis_cataloger] }
   end
+  describe '.set_restrictions' do
+    subject { SpatialDataRepository.set_restrictions }
+    it { should eq [:nyu_only] }
+  end
   describe '.before_loads' do
     subject { SpatialDataRepository.before_loads }
-    it { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link, :add_access_rights] }
+    it { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link] }
   end
 end

--- a/spec/resource_sets/spatial_data_repository_spec.rb
+++ b/spec/resource_sets/spatial_data_repository_spec.rb
@@ -5,7 +5,7 @@ describe SpatialDataRepository do
   subject { SpatialDataRepository.new(filename) }
   it { should be_a SpatialDataRepository }
   it { should be_a Ichabod::ResourceSet::Base }
-  its(:set_restrictions) { should eq ['nyu_only'] }
+  its(:set_restrictions) { should eq 'nyu_only' }
   its(:filename) { should eq filename }
   its(:editors) { should eq ['admin_group', 'gis_cataloger'] }
   its(:before_loads) { should eq [:add_edit_groups, :add_resource_set, :add_additional_info_link] }


### PR DESCRIPTION
@jgpawletko @NYULibraries/hydra ,

Creating a PR for this [user story](https://www.pivotaltracker.com/n/projects/1025368/stories/92124688). I have a few questions. Part of my user story is to have controlled vocabulary for the field restrictions. I tried to do an enum attribute but it wasn't allowing me to do it for ActiveFedora. So, right now, I'm just populating the restrictions value from a yml file. I would like to check though to make sure that the value added for restrictions is only one of the two values currently defined in the user story. If you all have suggestions as to how best to do that, I would appreciate it.

Thanks.

Esha