### PR TITLE
Functioning OAI Provider in place. Simple DC Only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'iso-639'
 gem 'faraday', '~> 0.9.0'
 gem 'multi_json', '~> 1.10.1'
 gem 'multi_xml', '~> 0.5.5'
+gem 'blacklight_oai_provider', github: 'cbeer/blacklight_oai_provider'
 
 group :development do
   gem 'better_errors', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,15 @@ GIT
       activesupport (>= 3.2)
 
 GIT
+  remote: git://github.com/cbeer/blacklight_oai_provider.git
+  revision: f603f8c0db19baf7a9a11b8a6a682697c8d23e2f
+  specs:
+    blacklight_oai_provider (0.1.1)
+      blacklight (>= 3.0)
+      oai
+      rails (>= 3.0)
+
+GIT
   remote: git://github.com/code4lib/ruby-oai.git
   revision: 2962523677f8619f646ea95ece490c8c3a43e742
   branch: master
@@ -552,6 +561,7 @@ DEPENDENCIES
   authpds-nyu!
   better_errors (~> 2.0.0)
   binding_of_caller
+  blacklight_oai_provider!
   coffee-rails (~> 4.0.0)
   compass-rails (~> 2.0.0)
   coveralls (~> 0.7.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,6 +4,8 @@ require 'blacklight/catalog'
 class CatalogController < ApplicationController
 
   include Blacklight::Catalog
+  include BlacklightOaiProvider::ControllerExtension
+
   include Hydra::Controller::ControllerBehavior
   # These before_filters apply the hydra access controls
   # before_filter :enforce_show_permissions, :only=>:show
@@ -180,6 +182,19 @@ class CatalogController < ApplicationController
     #define what parials will be used to display each solr document
     config.index.partials = ['index_header','index','action_buttons']
     config.show.partials = ['show_header','show','action_buttons']
+    config.oai = {
+      :repository_url => 'http://localhost',
+      :provider => {
+        :repository_name => 'Test',
+        :repository_url => 'http://localhost',
+        :record_prefix => '',
+        :admin_email => 'root@localhost'
+      },
+      :document => {
+        :timestamp => 'timestamp',
+        :limit => 25
+      }
+    }
 
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -2,6 +2,8 @@
 class SolrDocument
 
   include Blacklight::Solr::Document
+  SolrDocument.use_extension( BlacklightOaiProvider::SolrDocumentExtension )
+
       # The following shows how to setup this blacklight document to display marc documents
   extension_parameters[:marc_source_field] = :marc_display
   extension_parameters[:marc_format_type] = :marcxml
@@ -33,10 +35,27 @@ class SolrDocument
   # and Blacklight::Solr::Document#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension( Blacklight::Solr::Document::DublinCore)
+  # Notes from 20150613
+  # Field Semantics here only supports Unqualified Dublin Core.
+  # In order to provide support for other formats (including Nyucore)
+  # I think we need to define one or more Export Formats.
+  # http://www.rubydoc.info/github/projectblacklight/blacklight/Blacklight/Document/Export
+  # THen oai_provider _may_ be configurable to support them.
+  # unapi definitely is: https://github.com/cbeer/blacklight_unapi
   field_semantics.merge!(
-                         :title => "title_display",
-                         :author => "author_display",
-                         :language => "language_facet",
-                         :format => "format"
+                         :identifier => "desc_metadata__identifier_tesim",
+                         :title => "desc_metadata__title_tesim",
+                         :publisher => "desc_metadata__publisher_tesim",
+                         :type => "desc_metadata__type_tesim",
+                         :description => "desc_metadata__description_tesim",
+                         :available => "desc_metadata__available_tesim",
+                         :edition => "desc_metadata__edition_tesim",
+                         :series => "desc_metadata__series_tesim",
+                         :version => "desc_metadata__version_tesim",
+                         :restrictions => "desc_metadata__restrictions_tesim",
+                         :addinfolink => "desc_metadata__addinfolink_tesim",
+                         :addinfotext => "desc_metadata__addinfotext_tesim",
+                         :isPartOf => "collection_ssm",
+                         :date => "timestamp"
                          )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Ichabod::Application.routes.draw do
 
   root :to => "catalog#index"
   Blacklight.add_routes(self)
-
+  get   '/oai', :to => 'catalog#oai'
   get 'login', :to => 'user_sessions#new', :as => :login
   get 'logout', :to => 'user_sessions#destroy', :as => :logout
   get 'validate', :to => 'user_sessions#validate', :as => :validate


### PR DESCRIPTION
Hey @NYULibraries/hydra 

Last night I made a first cut at putting an OAI provider into Ichabod. I have a few questions for the group, which I'm writing up here.

1. I'm using cbeer's OAI Provider. This has _no_ tests. Is that reason enough to build this out ourselves? We could follow the model used by WGBH here, which _does_ include tests:
https://github.com/WGBH/openvault/tree/master/app
2. I'm not sure how to test this on our end. We don't currently have a solr_document.spec file, though I can add one. Otherwise, would is it sufficient to add some cucumber tests that test the functionality itself? Is that even needed?
3. This only supports simple DC at this time. We'll have to build export profiles to do full Nyucore. Is simple sufficient for the first iteration of this user story?
4. The implementation applies a stylesheet when a browser requests text. Do we want this?

I appreciate any feedback you might have.

Thanks,
-Corey