### PR TITLE
update Gemfile for additional security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'compass-rails', '~> 2.0.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'therubyracer', '~> 0.12.0', platforms: :ruby
-gem 'jquery-rails', '~> 3.1.0'
+gem 'jquery-rails', '~> 3.1.3'
 gem 'jquery-ui-rails', '~> 5.0.0'
 gem 'jbuilder', '~> 2.1.3'
 
@@ -41,7 +41,7 @@ gem 'jettywrapper', group: [:development, :test, :staging]
 
 gem 'iso-639'
 gem 'faraday', '~> 0.9.0'
-gem 'multi_json', '~> 1.10.1'
+gem 'multi_json', '~> 1.11.1'
 gem 'multi_xml', '~> 0.5.5'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
       childprocess
       i18n
       logger
-    jquery-rails (3.1.2)
+    jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.2)
@@ -330,7 +330,7 @@ GEM
     mime-types (2.6.1)
     mini_portile (0.6.0)
     minitest (5.7.0)
-    multi_json (1.10.1)
+    multi_json (1.11.1)
     multi_test (0.1.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -370,7 +370,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.5.4)
+    rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.11)
@@ -560,10 +560,10 @@ DEPENDENCIES
   iso-639
   jbuilder (~> 2.1.3)
   jettywrapper
-  jquery-rails (~> 3.1.0)
+  jquery-rails (~> 3.1.3)
   jquery-ui-rails (~> 5.0.0)
   kaminari (~> 0.13)
-  multi_json (~> 1.10.1)
+  multi_json (~> 1.11.1)
   multi_xml (~> 0.5.5)
   mustache (= 0.99.4)
   mustache-rails!


### PR DESCRIPTION
Update `jquery-rails` and `multi_json` gems.
Did not run full `bundle update` because it introduced many deprecation warnings:
```
[DEPRECATION] `RSolr.escape` is deprecated (and incorrect).  Use `Rsolr.solr_escape` instead.
```