### PR TITLE
Modify .travis.yml to use Travis container infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 
 rvm:


### PR DESCRIPTION
## Highlights

* update `.travis.yml` to enable builds on Travis' new [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/), which runs jobs more quickly than the old Travis infrastructure