### PR TITLE
disable The Masses collection facet feature for now

### DIFF
--- a/features/collection_facet.feature
+++ b/features/collection_facet.feature
@@ -36,6 +36,7 @@ Feature: Collection facet
     When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
     Then I should see search results
 
+  @wip
   Scenario: Filter by The Masses
     Given I am on the default search page
     When I filter my search to "The Masses" under the "Collection" category


### PR DESCRIPTION
## Highlights
* disable `The Masses` collection facet scenario.
  * the collection is not being loaded at this time, and the scenario is failing intermittently
  * disabling until we have enough bandwidth to determine root cause
