### PR TITLE
Need feedback chore/redo dataset by prefix

### DIFF
--- a/lib/ichabod/resource_set/base.rb
+++ b/lib/ichabod/resource_set/base.rb
@@ -149,17 +149,31 @@ module Ichabod
         end.compact
       end
 
-      def delete
-        read_from_source if resources.empty?
-        resources.collect do |resource|
-          unless resource.is_a?(Resource)
-            raise RuntimeError.new("Expecting #{resource} to be a Resource")
-          end
-          nyucore = Nyucore.find(pid: resource.pid).first
-          nyucore.destroy if nyucore
-          nyucore
+      def get_records_by_prefix
+        raise_runtime_error_if_no_prefix_specified
+        prefix = self.class.prefix
+        @resources = Nyucore.where("id:#{prefix}*")
+        @resources.reject! do |r|
+          r.pid !~ /^#{prefix}:.*/
         end
       end
+
+      def delete
+        get_records_by_prefix if resources.empty?
+        resources.collect do |resource|
+          if resource.is_a?(Resource)
+            nyucore = Nyucore.find(pid: resource.pid).first
+            nyucore.destroy if nyucore
+            nyucore
+          elsif resource.is_a?(Nyucore)
+            resource.destroy 
+            resource
+          else
+            raise RuntimeError.new("Expecting #{resource} to be of type Nyucore or Resource")
+          end
+        end
+      end
+
 
       private
 
@@ -195,6 +209,12 @@ module Ichabod
         @name ||= self.class.name.demodulize.underscore
       end
 
+      def raise_runtime_error_if_no_prefix_specified
+        if self.class.prefix.blank?
+          raise RuntimeError.new("No prefix has been specified for the class #{self.class.name}")
+        end
+      end
+      
       def before_load_methods
         @before_load_methods ||= begin
           before_loads.collect do |before_load|

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -5,14 +5,11 @@ module Ichabod
       let(:before_loads) { [:method1, :method2] }
       let!(:original_before_loads) { Base.before_loads - before_loads }
       let(:set_restrictions) { [:nyu_only] }
-      let(:all_restrictions) { [:nyu_only, :authorized_only] }
-      let(:invalid_set_restrictions) { [:only_nyu] }
-      let!(:original_set_restrictions) { [] }
       let(:editors) { [:editor1, :editor2] }
-      let!(:original_editors) { Base.editors - editors }
+      let(:original_editors) { Base.editors - editors }
       let(:prefix) { 'mock' }
+=begin
       describe '.prefix=' do
-        after { Base.prefix=(nil)}
         subject { Base.prefix=(prefix) }
         it 'should not raise an ArgumentError' do
           expect { subject }.not_to raise_error
@@ -22,43 +19,41 @@ module Ichabod
           expect(Base.prefix).to eq prefix
         end
       end
+
       describe '.editor' do
-        after { Base.instance_variable_set(:@editors, original_editors)}
         subject { Base.editor(*editors) }
         it 'should not raise an ArgumentError' do
           expect { subject }.not_to raise_error
         end
         it 'should set the editors attribute on the class' do
           subject
-          expect(Base.editors).to eq editors.unshift(*original_editors)
+          expect(Base.editors).to eq (original_editors + editors)
         end
       end
+
       describe '.set_restriction' do
-        after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
         subject { Base.set_restriction(*set_restrictions) }
         it 'should not raise an ArgumentError' do
           expect { subject }.not_to raise_error
         end
         it 'should set the set_restrictions attribute on the class' do
           subject
-          expect(Base.set_restrictions).to eq set_restrictions.unshift(*original_set_restrictions)
+          expect(Base.set_restrictions).to eq set_restrictions
         end
       end
+
       describe '.before_load' do
-        after do
-          Base.instance_variable_set(:@before_loads, original_before_loads)
-        end
         subject { Base.before_load(*before_loads) }
         it 'should not raise an ArgumentError' do
           expect { subject }.not_to raise_error
         end
         it 'should set the before_loads attribute on the class' do
           subject
-          expect(Base.before_loads).to eq before_loads.unshift(*original_before_loads)
+          expect(Base.before_loads).to eq (original_before_loads + before_loads)
         end
       end
+
       describe '.source_reader=' do
-        after { Base.instance_variable_set(:@source_reader, nil)}
         subject { Base.source_reader=(source_reader) }
         context 'when the source_reader argument cannot be coerced into a SourceReader' do
           let(:source_reader) { 'invalid' }
@@ -95,48 +90,41 @@ module Ichabod
           end
         end
       end
+=end
+       #why are we testing the same functionality again??
       subject(:base) { Base.new }
       it { should be_a Base }
       describe '#each' do
         subject { base.each }
         it { should be_an Enumerator }
       end
-      describe '#size' do
-        subject { base.size }
-        context 'when we have read from source' do
-          before { Base.source_reader = ResourceSetMocks::MockSourceReader }
-          before { base.read_from_source }
-          after { Base.instance_variable_set(:@source_reader, nil) }
-          it { should be > 0 }
-        end
-        context 'when we have read from source' do
-          it { should eq 0 }
-        end
-      end
       describe '#prefix' do
         subject { base.prefix }
+        let(:p) { Base.prefix = nil }
         context 'when not configured with a prefix' do
-          it { should be_nil }
+          it { should eq p }
         end
         context 'when configured with a prefix' do
-          before { Base.prefix = prefix }
-          after { Base.prefix = nil}
-          it { should eq prefix }
+          let(:p) { Base.prefix = prefix }
+          it { should eq p }
         end
       end
+
       describe '#editors' do
         subject { base.editors }
         context 'when not configured with editors' do
+          let!(:orig_editor) { Base.editor(*original_editors) }
           it { should be_an Array }
-          it { should eq original_editors.map(&:to_s) }
+          it { should eq orig_editor.map(&:to_s) }
         end
         context 'when configured with editors' do
-          before { Base.editor(*editors) }
-          after { Base.instance_variable_set(:@editors, original_editors)}
+          let!(:all) { original_editors + editors }
+          let!(:b_editors) { Base.editor(*editors) }
           it { should be_an Array }
-          it { should eq editors.map(&:to_s).unshift(*original_editors.map(&:to_s)) }
+          it { should eq all.map(&:to_s) }
         end
       end
+=begin
       describe '#set_restrictions' do
         subject { base.set_restrictions }
         context 'when not configured with set_restrictions' do
@@ -181,6 +169,21 @@ module Ichabod
         end
         context 'when there is no source reader configured' do
           before { Base.instance_variable_set(:@source_reader, nil) }
+          it 'should raise a RuntimeError' do
+            expect { subject }.to raise_error RuntimeError
+          end
+        end
+      end
+      describe '#get_records_by_prefix' do
+        before { Base.prefix= prefix  }
+        subject { base.get_records_by_prefix }
+        it 'should assign the @resources instance variable' do
+          expect(base.instance_variable_get(:@resources)).to be_nil
+          subject
+          expect(base.instance_variable_get(:@resources)).not_to be_nil
+        end
+        context 'when there is no prefix configured' do
+          before { Base.prefix = nil  }
           it 'should raise a RuntimeError' do
             expect { subject }.to raise_error RuntimeError
           end
@@ -271,5 +274,7 @@ module Ichabod
         end
       end
     end
+=end
+  end
   end
 end

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -102,7 +102,7 @@ module Ichabod
         subject { base.prefix }
         let(:p) { Base.prefix = nil }
         context 'when not configured with a prefix' do
-          it { should eq p }
+          it { should eq p } 
         end
         context 'when configured with a prefix' do
           let(:p) { Base.prefix = prefix }
@@ -124,19 +124,17 @@ module Ichabod
           it { should eq all.map(&:to_s) }
         end
       end
-=begin
+
       describe '#set_restrictions' do
         subject { base.set_restrictions }
         context 'when not configured with set_restrictions' do
+          let!(:no_set_restrictions) { [] }
+          let!(:no_restrictions) { Base.set_restriction(*no_set_restrictions) }
           it { should be_a String }
-          it { should eq original_set_restrictions.join("") }
+          it { should be_empty }
         end
-        context 'when configured with set_restrictions' do
-          before { Base.set_restriction(*set_restrictions) }
-          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
-          it { should be_a String }
-          it { should eq set_restrictions.join("") }
-        end
+      end
+=begin
         context 'when configured with a value other than what is allowed for set_restrictions' do
           before { Base.set_restriction(*invalid_set_restrictions) }
           after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
@@ -144,6 +142,7 @@ module Ichabod
           it { should_not include all_restrictions.map(&:to_s).join("")  }
         end
       end
+
       describe '#before_loads' do
         subject { base.before_loads }
         context 'when not configured with before loads' do

--- a/spec/ichabod/resource_set/base_spec.rb
+++ b/spec/ichabod/resource_set/base_spec.rb
@@ -4,54 +4,11 @@ module Ichabod
     describe Base do
       let(:before_loads) { [:method1, :method2] }
       let!(:original_before_loads) { Base.before_loads - before_loads }
+      let(:original_restrictions) { nil }
       let(:set_restrictions) { [:nyu_only] }
       let(:editors) { [:editor1, :editor2] }
       let(:original_editors) { Base.editors - editors }
       let(:prefix) { 'mock' }
-=begin
-      describe '.prefix=' do
-        subject { Base.prefix=(prefix) }
-        it 'should not raise an ArgumentError' do
-          expect { subject }.not_to raise_error
-        end
-        it 'should set the prefix attribute on the class' do
-          subject
-          expect(Base.prefix).to eq prefix
-        end
-      end
-
-      describe '.editor' do
-        subject { Base.editor(*editors) }
-        it 'should not raise an ArgumentError' do
-          expect { subject }.not_to raise_error
-        end
-        it 'should set the editors attribute on the class' do
-          subject
-          expect(Base.editors).to eq (original_editors + editors)
-        end
-      end
-
-      describe '.set_restriction' do
-        subject { Base.set_restriction(*set_restrictions) }
-        it 'should not raise an ArgumentError' do
-          expect { subject }.not_to raise_error
-        end
-        it 'should set the set_restrictions attribute on the class' do
-          subject
-          expect(Base.set_restrictions).to eq set_restrictions
-        end
-      end
-
-      describe '.before_load' do
-        subject { Base.before_load(*before_loads) }
-        it 'should not raise an ArgumentError' do
-          expect { subject }.not_to raise_error
-        end
-        it 'should set the before_loads attribute on the class' do
-          subject
-          expect(Base.before_loads).to eq (original_before_loads + before_loads)
-        end
-      end
 
       describe '.source_reader=' do
         subject { Base.source_reader=(source_reader) }
@@ -90,76 +47,17 @@ module Ichabod
           end
         end
       end
-=end
-       #why are we testing the same functionality again??
+
       subject(:base) { Base.new }
       it { should be_a Base }
       describe '#each' do
         subject { base.each }
         it { should be_an Enumerator }
       end
-      describe '#prefix' do
-        subject { base.prefix }
-        let(:p) { Base.prefix = nil }
-        context 'when not configured with a prefix' do
-          it { should eq p } 
-        end
-        context 'when configured with a prefix' do
-          let(:p) { Base.prefix = prefix }
-          it { should eq p }
-        end
-      end
 
-      describe '#editors' do
-        subject { base.editors }
-        context 'when not configured with editors' do
-          let!(:orig_editor) { Base.editor(*original_editors) }
-          it { should be_an Array }
-          it { should eq orig_editor.map(&:to_s) }
-        end
-        context 'when configured with editors' do
-          let!(:all) { original_editors + editors }
-          let!(:b_editors) { Base.editor(*editors) }
-          it { should be_an Array }
-          it { should eq all.map(&:to_s) }
-        end
-      end
-
-      describe '#set_restrictions' do
-        subject { base.set_restrictions }
-        context 'when not configured with set_restrictions' do
-          let!(:no_set_restrictions) { [] }
-          let!(:no_restrictions) { Base.set_restriction(*no_set_restrictions) }
-          it { should be_a String }
-          it { should be_empty }
-        end
-      end
-=begin
-        context 'when configured with a value other than what is allowed for set_restrictions' do
-          before { Base.set_restriction(*invalid_set_restrictions) }
-          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
-          it { should be_a String }
-          it { should_not include all_restrictions.map(&:to_s).join("")  }
-        end
-      end
-
-      describe '#before_loads' do
-        subject { base.before_loads }
-        context 'when not configured with before loads' do
-          it { should be_an Array }
-          it { should eql original_before_loads }
-        end
-        context 'when configured with before loads' do
-          before { Base.before_load(*before_loads) }
-          after do
-            Base.instance_variable_set(:@before_loads, original_before_loads)
-          end
-          it { should eq before_loads.map(&:to_sym).unshift(*original_before_loads.map(&:to_sym)) }
-        end
-      end
       describe '#read_from_source' do
         before { Base.source_reader = ResourceSetMocks::MockSourceReader }
-        after { Base.instance_variable_set(:@source_reader, nil) }
+        let(:base) { Base.new }
         subject { base.read_from_source }
         it 'should assign the @resources instance variable' do
           expect(base.instance_variable_get(:@resources)).to be_nil
@@ -173,6 +71,7 @@ module Ichabod
           end
         end
       end
+
       describe '#get_records_by_prefix' do
         before { Base.prefix= prefix  }
         subject { base.get_records_by_prefix }
@@ -188,9 +87,9 @@ module Ichabod
           end
         end
       end
+
       describe '#load' do
         before { Base.source_reader = ResourceSetMocks::MockSourceReader }
-        after { Base.instance_variable_set(:@source_reader, nil) }
         subject { base.load }
         it { should be_an Array }
         it { should_not be_empty }
@@ -204,38 +103,38 @@ module Ichabod
           end
         end
         context 'when there are no editors' do
-          before { base.delete }
-          before { Base.instance_variable_set(:@editors, original_editors)}
+          let!(:editor) { Base.set_restriction(*original_editors) }
+          #before { base.instance_variable_set(:@editors, [original_editors])}
           it 'should return an array of Nyucores with no edit groups' do
             subject.each do |nyucore|
               expect(nyucore.edit_groups).to eq original_editors.map(&:to_s)
             end
           end
         end
-         context 'when there are no restrictions' do
-          before { base.delete }
-          before { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+      
+        context 'when there are no restrictions' do
+          let!(:restrictions) { Base.set_restriction(*original_restrictions) }
           it 'should return an array of Nyucores with no restrictions' do
             subject.each do |nyucore|
               expect(nyucore.restrictions).to be_nil
             end
           end
         end
+
         context 'when there are editors', vcr: {cassette_name: 'resource sets/load resource set with editors'} do
-          before { Base.editor(*editors) }
-          after { Base.instance_variable_set(:@editors, original_editors)}
+          let!(:editor) { Base.editor(*editors) }
+          let!(:all) { original_editors + editors }
           it { should be_an Array }
           it { should_not be_empty }
           its(:size) { should eq 5 }
           it 'should return an array of Nyucores with the specified edit groups' do
             subject.each do |nyucore|
-              expect(nyucore.edit_groups).to eq editors.map(&:to_s).unshift(*original_editors.map(&:to_s))
+              expect(nyucore.edit_groups).to eq all.map(&:to_s)
             end
           end
         end
         context 'when there are restrictions', vcr: {cassette_name: 'resource sets/load resource set with restrictions'} do
-          before { Base.set_restriction(*set_restrictions) }
-          after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}
+          let!(:restrictions) { Base.set_restriction(*set_restrictions) }
           it { should be_an Array }
           it { should_not be_empty }
           its(:size) { should eq 5 }
@@ -245,17 +144,12 @@ module Ichabod
             end
           end
         end
-        context 'when there is no source reader configured' do
-          before { Base.instance_variable_set(:@source_reader, nil) }
-          it 'should raise a RuntimeError' do
-            expect { subject }.to raise_error RuntimeError
-          end
-        end
       end
+
       describe '#delete' do
         before { Base.source_reader = ResourceSetMocks::MockSourceReader }
+        before { Base.prefix = prefix }
         before { base.load }
-        after { Base.instance_variable_set(:@source_reader, nil) }
         subject { base.delete }
         it 'should return an array of deleted Nyucores' do
           subject.each do |nyucore|
@@ -264,8 +158,8 @@ module Ichabod
             expect(nyucore).to be_destroyed
           end
         end
-        context 'when there is no source reader configured' do
-          before { Base.instance_variable_set(:@source_reader, nil) }
+        context 'when there is no prefix configured' do
+          before { Base.prefix = nil }
           before { base.instance_variable_set(:@resources, nil) }
           it 'should raise a RuntimeError' do
             expect { subject }.to raise_error RuntimeError
@@ -273,7 +167,5 @@ module Ichabod
         end
       end
     end
-=end
-  end
   end
 end


### PR DESCRIPTION
@NYULibraries/hydra 
Referencing #154. This has been a futile exercise for me. I tried to re-factor this spec but to no avail. I'll include Barnaby's comments but I need help in figuring this out. So, here is what I have figured out:
1. To me, the original base_spec seemed to have a lot of redundant testing. It tested the methods, then the base object, and then the nyucore resource that is derived from the Base class. But they all test the same thing. So, I wasn't sure if all of that was necessary and wiped it out just to see if I could get the nyucore tests happen correctly. No joy with that. Also, the Base class itself was being changed which is why the editor and restrictions tests kept failing inconsistently depending on the order in which the tests were running. Basically, if the no editor and no restrictions tests run first, the tests all run fine.
2. I tried to create a base object but I can't access the write methods. When I tried to do a base instance variable set, in order to change the object being tested and not the Base class, I still wasn't able to get the tests to run consistently.
3. It would be great to have someone with better rspec expertise to take a look and see what can be done. I changed the Base class to do something very simple: instead of having the delete function read from source again, I'm just accepting the prefix as a param and deleting it. These changes have really broken the spec because for the editor and restrictions tests, the test was relying on base delete to wipe out the pre-existing object, and re-load a fresh object.
4. Final note: I want to use let! as an instance variable(instead of the before hook) but since I was unable to access the class's write methods as a base object, I had to keep accessing the class. I can access the write methods in its subclass, ResourceSet. This is the central problem of this whole thing. The class changes and makes for an unpredictable testing environment. I don't really want to re-write the class because it's working well but I'm not sure how to create viable tests for it. Barnaby had mentioned to leave some of the testing for the subclass. Then do I just test for non-existence of data, i.e. if editors and restrictions are not specified, they should return their default values and leave the write methods testing for the resourceset specs(which is already happening)? This would greatly simplify the tests.

I'm attaching Barnaby's comments again:
> I had asked Barnaby for an analysis as to why this is happening. He told me the following:
> This spec has gotten a bit complicated. It is using too much of the program to conduct its tests when you really want to be testing explicit expectations as opposed to having the program check back on itself:

> So `expect(nyucore.edit_groups).to eql ["admin_group"]` as opposed to creating a new function to abstract what that eventually becomes.

> Also the before and afters are a bit confusing since every unit test should be self contained so an after state should never have to be called to revert something into another form for another test.

> Also, named subjects outside a scoped describe or context make things very confusing for rspec and may be a cause of inconsistency ( line 98). It also looks like you're trying to test with Base what you should be testing with its subclasses. Base is meant as an abstract class and so trying to make it do everything that every subclass might do is making a long difficult spec.

> Rspecs don't run in linear order (you can change how they run but it's generally randomly seeded) so if you are affecting a shared class in an `after` of another spec it will inconsistently fail.

> My solution was to remove everything except the tests in question and they do persistently pass. And then work backward: Look at statements like `after { Base.instance_variable_set(:@set_restrictions, original_set_restrictions)}` and `after { Base.instance_variable_set(:@editors, original_editors)}` which are called in other specs but are changing the Base class itself. 

> And sure enough reintroducing those specs, reintroduce the instability. 

> I think you need to reevaluate what it is you're trying to test. If it's trying to make Base match every possible subclass then it's trying to do too much.

> Final warning about let! and lazy lets: be wary of when certain variables are being set and make a clear different between what you're changing in base (the instance var) and Base (the class). It's not clear to me. If you're trying to figure out what is being changed where you'll have to pry into the Base class at various levels of the rspec. But that may be complicated debugging for what I think is the responsibility of the individual SourceReaders.

I've taken a stab at it and failed quite miserably. So, someone with more rspec knowledge will go much further.
