### PR TITLE
Chore/fixed collection facet

### DIFF
--- a/app/models/nyucore/collections.rb
+++ b/app/models/nyucore/collections.rb
@@ -11,7 +11,8 @@ class Nyucore < ActiveFedora::Base
       "Archive of Contemporary Composers' Websites" => ->(nyucore){ nyucore.resource_set == 'archive_it_accw' },
       'Asian NGOs Reports' => ->(nyucore){ nyucore.resource_set == 'faculty_digital_archive_ngo'},
       'NYU Press Open Access Books' => ->(nyucore){ nyucore.resource_set == 'nyu_press_open_access_book' },
-      'Data Services' => ->(nyucore){ nyucore.resource_set == 'faculty_digital_archive_service_data' }
+      'Data Services' => ->(nyucore){ nyucore.resource_set == 'faculty_digital_archive_service_data' },
+      'The Masses' => ->(nyucore){ nyucore.resource_set == 'masses' }
     }
 
     attr_reader :nyucore

--- a/features/collection_facet.feature
+++ b/features/collection_facet.feature
@@ -10,47 +10,44 @@ Feature: Collection facet
 
   Scenario: Filter by multiple intersecting collections
     Given I am on the default search page
-    When I filter my search to "ESRI" under the "Collection" category
-    And I filter my search to "Spatial Data Repository" under the "Collection" category
+    When I filter my search to "ESRI, Spatial Data Repository" under the "Collection" category
     Then I should see search results
 
-  @wip @vcr
+  @vcr
   Scenario: Filter by The Real Rosie the Riveter
     Given I am on the default search page
     When I filter my search to "The Real Rosie the Riveter" under the "Collection" category
     Then I should see search results
 
-  @wip @vcr
+  @vcr
   Scenario: Filter by Voices of the Food Revolution
     Given I am on the default search page
     When I filter my search to "Voices of the Food Revolution" under the "Collection" category
     Then I should see search results
-  @wip
+
   Scenario: Filter by The Asian NGOs Reports
     Given I am on the default search page
     When I filter my search to "Asian NGOs Reports" under the "Collection" category
     Then I should see search results
 
- @wip
   Scenario: Filter by Archive of Contemporary Composers Websites
     Given I am on the default search page
     When I filter my search to "Archive of Contemporary Composers' Websites" under the "Collection" category
     Then I should see search results
 
-  @wip
   Scenario: Filter by The Masses
     Given I am on the default search page
     When I filter my search to "The Masses" under the "Collection" category
     Then I should see search results
 
- @wip
   Scenario: Filter by The Data Service Collection
     Given I am on the default search page
     When I filter my search to "Data Services" under the "Collection" category
     Then I should see search results
 
-  @wip
+
   Scenario: Filter by Research Guides
     Given I am on the default search page
     When I filter my search to "Research Guides" under the "Collection" category
     Then I should see search results
+

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -35,14 +35,14 @@ end
 
 ##
 # Faceting steps
-Given(/^I (limit|filter) my search to "(.*?)" under the "(.*?)" category$/) do |a, facet, category|
+Given(/^I (limit|filter) my search to "([^\"]*)" under the "(.*?)" category$/) do |a, facet, category|
   ensure_root_path
-  limit_by_facet(category, facet)
+  limit_by_facets(category, facet)
 end
 
-When(/^I limit my results to "(.*?)" under the "(.*?)" category$/) do |facet, category|
+When(/^I limit my results to "([^\"]*)" under the "(.*?)" category$/) do |facet, category|
   ensure_root_path
-  limit_by_facet(category, facet)
+  limit_by_facets(category, facet)
 end
 
 And(/^I should see a "(.*?)" facet under the "(.*?)" category$/) do |facet, category|

--- a/features/support/helpers/search.rb
+++ b/features/support/helpers/search.rb
@@ -5,10 +5,14 @@ module IchabodFeatures
       visit root_path unless current_path == root_path
     end
 
-    def limit_by_facet(category, facet)
+
+    def limit_by_facets(category, facets)
       within(:css, '#facets') do
         click_on(category)
-        click_on(facet)
+        sleep(2)
+        facets.split(", ").each do |facet|
+          click_on(facet)
+        end
       end
     end
 


### PR DESCRIPTION
This pull request modifies 2 things in the way we choose facets:
1. Now when we want to choose a specific facet within a category, we wait for 2 seconds. Thus we have enough time to load the full list of facets.
2. Now we can choose several facets within category, because they are passed as an array.

I replace method "limit_by_facet", which takes category and facet as parameters with method "limit_by_facets", which takes category and array of facets as parameters. 
 