### PR TITLE
Feature/106210416 creator info for nyupress oa books

### DIFF
--- a/features/display.feature
+++ b/features/display.feature
@@ -53,4 +53,4 @@ Feature: Various display tests
     Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
     And I search for "9780814712917"
     When I navigate to details display of the first result
-    Then I should see the value "Jody David Armour" in the "Creator:" field
+    Then I should see the value "Gail R. Benjamin" in the "Creator:" field

--- a/features/display.feature
+++ b/features/display.feature
@@ -45,10 +45,12 @@ Feature: Various display tests
 
   Scenario: Display "Book" field in the details display
     Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
+    And I search for "9780814712917"
     When I navigate to details display of the first result
     Then I should see the value "Book" in the "Format:" field
 
   Scenario: Display "Creator" field in the details display
     Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
+    And I search for "9780814712917"
     When I navigate to details display of the first result
     Then I should see the value "Jody David Armour" in the "Creator:" field

--- a/features/display.feature
+++ b/features/display.feature
@@ -43,3 +43,8 @@ Feature: Geospatial dataset's various display tests
     Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
     When I navigate to details display of the first result
     Then I should see the value "Book" in the "Format:" field
+
+  Scenario: Display "Creator" field in the details display
+    Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
+    When I navigate to details display of the first result
+    Then I should see the value "Jody David Armour" in the "Creator:" field

--- a/features/display.feature
+++ b/features/display.feature
@@ -1,8 +1,12 @@
-Feature: Geospatial dataset's various display tests
+Feature: Various display tests
   In order to use a Geospatial dataset
   As an on-campus NYU patron
   Once I’ve found a dataset in Ichabod, I need to be able to click on a download link
   Once I've found a geospatial dataset, I would like to know my access restrictions
+  In order to use the NYU Press Open Access Books collection
+  As an on-campus NYU patron
+  Once I’ve found a record for a book in Ichabod
+  I need to be able to see in the details display both "Format: Book" and "Creator: [X]"
 
   Scenario: Display "Online Resource" field in search results
     Given I am on the default search page

--- a/features/display.feature
+++ b/features/display.feature
@@ -33,13 +33,13 @@ Feature: Geospatial dataset's various display tests
     And I limit my results to "Geospatial Data" under the "Format" category
     Then I should get "Access Restrictions" field and its corresponding value "NYU Only" in all results
     
- Scenario: Display "Access restrictions" field in the details display
+  Scenario: Display "Access restrictions" field in the details display
     Given I limit my search to "Geospatial Data" under the "Format" category
     And I search for "LION"
     When I navigate to details display of the first result
     Then I should see the value "NYU Only" in the "Access Restrictions:" field
 
-Scenario: Display "Book" field in the details display
+  Scenario: Display "Book" field in the details display
     Given I limit my search to "NYU Press Open Access Books" under the "Collection" category
     When I navigate to details display of the first result
     Then I should see the value "Book" in the "Format:" field

--- a/lib/ichabod/resource_set/source_readers/nyu_press_open_access_book_reader.rb
+++ b/lib/ichabod/resource_set/source_readers/nyu_press_open_access_book_reader.rb
@@ -24,6 +24,7 @@ module Ichabod
             identifier: entity['id'],
             isbn: entity['id'],
             title: entity['title'],
+            creator: entity['author'],
             available: entity['handle'],
             citation: entity['handle'],
             date: entity['date'],

--- a/spec/ichabod/resource_set/source_readers/nyu_press_open_access_book_reader_spec.rb
+++ b/spec/ichabod/resource_set/source_readers/nyu_press_open_access_book_reader_spec.rb
@@ -35,6 +35,7 @@ module Ichabod
             its(:identifier) { should eq '9780814706404' }
             its(:isbn) { should eq '9780814706404' }
             its(:title) { should eq 'Negrophobia and Reasonable Racism' }
+            its(:creator) { should match_array ['Jody David Armour'] }
             its(:available) { should eq 'http://hdl.handle.net/2333.1/37pvmfhh' }
             its(:citation) { should eq 'http://hdl.handle.net/2333.1/37pvmfhh' }
             its(:type) { should eq 'Book' }


### PR DESCRIPTION
* Map NYU Press Open Access Books `author` field to `creator`.
* Update `display.feature`
  * Make Feature header text more general
  * Add test for Creator being displayed in detail page
  * Make tests always run against a single specific book instead of first record in collection search resutls
  * Whitespace reformatting
* Update rspec for `NyuPressOpenAccessBookReader`