### PR TITLE
update nokogiri to 1.6.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       net-ssh (>= 2.6.5)
     netrc (0.11.0)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.7.1)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)


### PR DESCRIPTION
Address CVE-2015-7499
https://groups.google.com/forum/#!topic/ruby-security-ann/Dy7YiKb_pMM
