### PR TITLE
Feature/113551301 update readme with current data load examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,23 @@ Students, faculty, researchers - can search through collection metadata and get 
 ## Sample Data Ingest
 
 Rake tasks available to ingest data from "ingest" directory.
-
+```
+    rake ichabod:load['nyu_press_open_access_book','http://discovery.dlib.nyu.edu:8080/solr3_discovery/nyupress/select']
+    # Load first five records only (start = 0, rows = 5)
+    rake ichabod:load['nyu_press_open_access_book','http://discovery.dlib.nyu.edu:8080/solr3_discovery/nyupress/select','0','5']
+```
+```
+    rake ichabod:load['faculty_digital_archive_ngo','https://archive.nyu.edu/request','hdl_2451_33605']
+    # Load five records only (rows = 5)
+    rake ichabod:load['faculty_digital_archive_ngo','https://archive.nyu.edu/request','hdl_2451_33605','5']
+```
+```
     rake ichabod:load['spatial_data_repository','./ingest/sdr.xml']
-
+```
 ... and to purge data based on same data files.
 
+    rake ichabod:delete['nyu_press_open_access_book','http://discovery.dlib.nyu.edu:8080/solr3_discovery/nyupress/select']
+    rake ichabod:delete['faculty_digital_archive_ngo','https://archive.nyu.edu/request','hdl_2451_33605']
     rake ichabod:delete['spatial_data_repository','./ingest/sdr.xml']
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ Students, faculty, researchers - can search through collection metadata and get 
 Rake tasks available to ingest data from "ingest" directory.
 
     rake ichabod:load['spatial_data_repository','./ingest/sdr.xml']
-    rake ichabod:load['faculty_digital_archive','./ingest/stern.xml']
 
 ... and to purge data based on same data files.
 
     rake ichabod:delete['spatial_data_repository','./ingest/sdr.xml']
-    rake ichabod:delete['faculty_digital_archive','./ingest/stern.xml']
 
 ## Resources
 


### PR DESCRIPTION
Resolves [#113551301: Update `rake ichabod:load and ichabod:delete` examples in README.md](https://www.pivotaltracker.com/projects/1025368/stories/113551301).

Ideally this should be merged after PR [#210](https://github.com/NYULibraries/ichabod/pull/210), because it contains an example load that won't work until branch [bugfix/113552525_rake-ichabod-load-fda-ngo-fails-if-specifying-rows-paramter](https://github.com/NYULibraries/ichabod/tree/bugfix/113552525_rake-ichabod-load-fda-ngo-fails-if-specifying-rows-paramter) is merged.