### PR TITLE
oai_dc_http_reader.rb BUGFIX: cast load_number_of_records to int when…

### DIFF
--- a/lib/ichabod/resource_set/source_readers/oai_dc_http_reader.rb
+++ b/lib/ichabod/resource_set/source_readers/oai_dc_http_reader.rb
@@ -39,7 +39,7 @@ module Ichabod
         def records
          @records=[]
          unless load_number_of_records.nil?
-           response_oai.first(load_number_of_records).each { |oai_record| @records << oai_record.metadata }
+           response_oai.first(load_number_of_records.to_i).each { |oai_record| @records << oai_record.metadata }
          else
            response_oai.each { |oai_record| @records << oai_record.metadata }
          end


### PR DESCRIPTION
… passing to response_oai.first()

Resolves [##113552525: rake ichabod:load for faculty_digital_archive_ngo fails if specifying rows parameter](https://www.pivotaltracker.com/projects/1025368/stories/113552525).

Note that `faculty_digital_archive_ngo_spec.rb` does not need to be changed because an integer was used for testing.