### PR TITLE
Chore/113569497 update nyucore yaml file display in order

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,11 +48,10 @@ class CatalogController < ApplicationController
     #    if M
 
     FACET_FIELDS = MetadataFields.process_metadata_fields(section: 'facet')
-binding.pry()
-    config.add_facet_field solr_name('desc_metadata__type', :facetable), :label => 'Format'
-    config.add_facet_field solr_name('desc_metadata__creator', :facetable), :label => 'Creator'
-    config.add_facet_field solr_name('desc_metadata__subject', :facetable), :label => 'Subject'
-    config.add_facet_field solr_name('desc_metadata__language', :facetable), :label => 'Language'
+    FACET_FIELDS.each do |field|
+        config.add_facet_field solr_name("desc_metadata__#{field[:field]}", :facetable), :label => field[:label] 
+    end    
+    ## This is still here because it's not actually defined in Fedora or in Nyucore
     config.add_facet_field solr_name('collection', :facetable), :label => 'Collection'
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,6 +43,12 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
+    
+    #for field in MetadataFields.process_metadata_fields():
+    #    if M
+
+    FACET_FIELDS = MetadataFields.process_metadata_fields(section: 'facet')
+binding.pry()
     config.add_facet_field solr_name('desc_metadata__type', :facetable), :label => 'Format'
     config.add_facet_field solr_name('desc_metadata__creator', :facetable), :label => 'Creator'
     config.add_facet_field solr_name('desc_metadata__subject', :facetable), :label => 'Subject'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,9 +43,6 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    
-    #for field in MetadataFields.process_metadata_fields():
-    #    if M
 
     FACET_FIELDS = MetadataFields.process_metadata_fields(section: 'facet')
     FACET_FIELDS.each do |field|

--- a/app/models/concerns/metadata_fields.rb
+++ b/app/models/concerns/metadata_fields.rb
@@ -21,7 +21,6 @@ module MetadataFields
    	  # adding business logic here that handles "section" as well?
       # Might be clearner to have separate method?
       chk_key = ns.to_sym
-      puts chk_key
       fields = []
       ordered_fields = []
    	  if METADATA_FIELDS.has_key?(chk_key)

--- a/app/models/concerns/metadata_fields.rb
+++ b/app/models/concerns/metadata_fields.rb
@@ -23,7 +23,7 @@ module MetadataFields
       chk_key = ns.to_sym
       puts chk_key
       fields = []
-      ordered_fields = {}
+      ordered_fields = []
    	  if METADATA_FIELDS.has_key?(chk_key)
    	  	add_fields_by_ns(multiple,fields,chk_key)
       elsif section != "none"
@@ -32,7 +32,7 @@ module MetadataFields
    	  	add_all_fields(multiple,fields)
       end
       if ordered_fields.length > 0
-        fields = Hash[ordered_fields.sort_by{|k,v| v}].keys
+        fields = ordered_fields.sort_by { |record| record[:order] }
    	  end
       fields
    end
@@ -109,7 +109,9 @@ module MetadataFields
        display_in_section = "display_in_" + section
        section_order = section + "_order"
        if metadata_fields[field][display_in_section.to_sym] == true
-          ordered_fields[field] = metadata_fields[field][section_order]
+          ordered_fields.push({ :field => field, 
+                                :order => metadata_fields[field][section_order.to_sym], 
+                                :label => metadata_fields[field][:display_label] })
        end
      }
    end

--- a/app/models/concerns/metadata_fields.rb
+++ b/app/models/concerns/metadata_fields.rb
@@ -4,25 +4,37 @@ module MetadataFields
    
    NAMESPACE_ALL = 'all'
    MULTIPLE_ALL  = 'all'
+   SECTION_NONE = 'none'
    DEFAULT_NAMESPACE = NAMESPACE_ALL
    DEFAULT_MULTIPLE  = MULTIPLE_ALL
+   DEFAULT_SECTION = SECTION_NONE
 
    # get metadata fields
-   def process_metadata_fields(ns:DEFAULT_NAMESPACE, multiple: DEFAULT_MULTIPLE)
-   	  unless allowed_values(ns,multiple)
+   def process_metadata_fields(ns:DEFAULT_NAMESPACE, multiple: DEFAULT_MULTIPLE, section: DEFAULT_SECTION)
+   	  unless allowed_values(ns,multiple,section)
    	  	raise ArgumentError.new(
           "#{multiple} should be one of these values: #{allowed_values_for_multiple} 
-          or #{ns} should be one of these values: #{allowed_values_for_ns}")	
+          or #{ns} should be one of these values: #{allowed_values_for_ns}
+          or #{section} should be one of these values: #{allowed_values_for_section}")	
    	  end
 
-   	  chk_key = ns.to_sym
+   	  # adding business logic here that handles "section" as well?
+      # Might be clearner to have separate method?
+      chk_key = ns.to_sym
+      puts chk_key
       fields = []
+      ordered_fields = {}
    	  if METADATA_FIELDS.has_key?(chk_key)
    	  	add_fields_by_ns(multiple,fields,chk_key)
+      elsif section != "none"
+        add_all_by_section(multiple,ordered_fields,section)
    	  elsif ns == DEFAULT_NAMESPACE
    	  	add_all_fields(multiple,fields)
       end
-   	  fields
+      if ordered_fields.length > 0
+        fields = Hash[ordered_fields.sort_by{|k,v| v}].keys
+   	  end
+      fields
    end
    
    # get namespace and uri for
@@ -64,6 +76,13 @@ module MetadataFields
      }
    end
 
+   # output ordered fields by section regardless of namespace
+   def add_all_by_section(multiple,ordered_fields,section)
+     METADATA_FIELDS.keys.each { |ns|
+       add_fields_by_section(multiple,ordered_fields,ns,section) 
+     }
+   end   
+
    # add fields specified by namespace
    def add_fields_by_ns(multiple,fields,ns)
      #grabbing only fields
@@ -75,7 +94,23 @@ module MetadataFields
        output = ( multiple == DEFAULT_MULTIPLE ) ? 
                 true : 
                 metadata_fields[field][:multiple] == multiple
-	     fields.push(field) if output
+       fields.push(field) if output
+     }
+   end   
+
+   # add ordered fields by section specified by namespace
+   def add_fields_by_section(multiple,ordered_fields,ns,section)
+     #grabbing only fields
+     metadata_fields = METADATA_FIELDS[ns][:fields]
+     METADATA_FIELDS[ns][:fields].keys.each{ |field|
+       # if output is true then print out field
+       # if multiple has the default value
+       # or one of the values in the yml file
+       display_in_section = "display_in_" + section
+       section_order = section + "_order"
+       if metadata_fields[field][display_in_section.to_sym] == true
+          ordered_fields[field] = metadata_fields[field][section_order]
+       end
      }
    end
 
@@ -91,11 +126,18 @@ module MetadataFields
      values << DEFAULT_NAMESPACE
    end
 
-   def allowed_values(ns,multiple)
-      allowed_values_for_ns.include?(ns) && allowed_values_for_multiple.include?(multiple)
+   def allowed_values_for_section
+     ['search', 'full', 'facet', DEFAULT_SECTION]
    end
 
-   private_class_method :add_all_fields, :add_fields_by_ns, :allowed_values_for_multiple, :allowed_values_for_ns, :allowed_values,
-                        :get_all_sources_info, :get_metadata_source_info
+
+   def allowed_values(ns,multiple,section)
+      allowed_values_for_ns.include?(ns) && allowed_values_for_multiple.include?(multiple) && allowed_values_for_section.include?(section)
+   end
+
+   private_class_method :add_all_fields, :add_fields_by_ns, :allowed_values_for_multiple,
+                        :allowed_values_for_ns, :allowed_values_for_section, :allowed_values,
+                        :get_all_sources_info, :get_metadata_source_info, :add_all_by_section,
+                        :add_fields_by_section
 end
 

--- a/config/metadata_fields.yml
+++ b/config/metadata_fields.yml
@@ -19,6 +19,7 @@ terms:
           display_in_full: true
           full_order: 1
           display_in_facet: false
+          display_label: "Title"
         identifier:
           data_type: text
           facetable: false
@@ -55,6 +56,7 @@ terms:
           full_order: 2
           display_in_facet: true
           facet_order: 2
+          display_label: "Creator"
         date:
           data_type: date
           facetable: false
@@ -78,6 +80,7 @@ terms:
           display_in_full: true
           full_order: 8
           display_in_facet: false
+          display_label: "Description"
         format:
           data_type: text
           facetable: true
@@ -90,8 +93,8 @@ terms:
           search_order: 2
           display_in_full: true
           full_order: 3
-          display_in_facet: true
-          facet_order: 1
+          display_in_facet: false
+          display_label: "Format"
         language:
           data_type: text
           facetable: true
@@ -106,6 +109,7 @@ terms:
           full_order: 4
           display_in_facet: true
           facet_order: 4
+          display_label: "Language"
         publisher:
           data_type: text
           facetable: false
@@ -119,6 +123,7 @@ terms:
           display_in_full: true
           full_order: 6
           display_in_facet: false
+          display_label: "Publisher"
         relation:
           data_type: text
           facetable: false
@@ -131,6 +136,7 @@ terms:
           display_in_full: true
           full_order: 13
           display_in_facet: false
+          display_label: "Relation"
         rights:
           data_type: text
           facetable: false
@@ -143,6 +149,7 @@ terms:
           display_in_full: true
           full_order: 18
           display_in_facet: false
+          display_label: "Rights"
         subject:
           data_type: text
           facetable: true
@@ -155,6 +162,7 @@ terms:
           display_in_full: false
           display_in_facet: true
           facet_order: 3
+          display_label: "Subject"
         type:
           data_type: text
           facetable: false
@@ -166,7 +174,9 @@ terms:
           display_in_search: false
           display_in_full: true
           full_order: 7
-          display_in_facet: false
+          display_in_facet: true
+          facet_order: 1
+          display_label: "Format"
 
     ichabod:
       info:
@@ -186,6 +196,7 @@ terms:
           display_in_full: true
           full_order: 17
           display_in_facet: false
+          display_label: "Additional Information"
         addinfotext:
           data_type: text
           facetable: false
@@ -209,6 +220,7 @@ terms:
           display_in_full: true
           full_order: 16
           display_in_facet: false
+          display_label: "Data Provider"
         discoverable:
           data_type: text
           facetable: false
@@ -243,6 +255,7 @@ terms:
           display_in_full: true
           full_order: 5
           display_in_facet: false
+          display_label: "ISBN"
         location:
           data_type: text
           facetable: false
@@ -255,6 +268,7 @@ terms:
           display_in_full: true
           full_order: 14
           display_in_facet: false
+          display_label: "Location"
         repo:
           data_type: text
           facetable: false
@@ -267,6 +281,7 @@ terms:
           display_in_full: true
           full_order: 15
           display_in_facet: false
+          display_label: "Repository"
         resource_set:
           data_type: text
           facetable: false
@@ -322,6 +337,7 @@ terms:
           display_in_full: true
           full_order: 12
           display_in_facet: false
+          display_label: "Online Resource"
         citation:
           data_type: text
           facetable: false
@@ -357,6 +373,7 @@ terms:
           display_in_full: true
           full_order: 11
           display_in_facet: false
+          display_label: "Access Restrictions"
         series:
           data_type: text
           facetable: false
@@ -369,6 +386,7 @@ terms:
           display_in_full: true
           full_order: 9
           display_in_facet: false
+          display_label: "Series"
         version:
           data_type: text
           facetable: false
@@ -381,3 +399,4 @@ terms:
           display_in_full: true
           full_order: 10
           display_in_facet: false
+          display_label: "Version"

--- a/config/metadata_fields.yml
+++ b/config/metadata_fields.yml
@@ -14,6 +14,11 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: true
+          search_order: 1
+          display_in_full: true
+          full_order: 1
+          display_in_facet: false
         identifier:
           data_type: text
           facetable: false
@@ -22,8 +27,10 @@ terms:
           multiple: false
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         # Optional Fields
-
         contributor:
           data_type: text
           facetable: true
@@ -32,6 +39,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         creator:
           data_type: text
           facetable: true
@@ -40,6 +50,11 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 2
+          display_in_facet: true
+          facet_order: 2
         date:
           data_type: date
           facetable: false
@@ -48,6 +63,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         description:
           data_type: text
           facetable: false
@@ -56,6 +74,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 8
+          display_in_facet: false
         format:
           data_type: text
           facetable: true
@@ -64,6 +86,12 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: true
+          search_order: 2
+          display_in_full: true
+          full_order: 3
+          display_in_facet: true
+          facet_order: 1
         language:
           data_type: text
           facetable: true
@@ -72,6 +100,12 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: true
+          search_order: 3
+          display_in_full: true
+          full_order: 4
+          display_in_facet: true
+          facet_order: 4
         publisher:
           data_type: text
           facetable: false
@@ -80,6 +114,11 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: true
+          search_order: 4
+          display_in_full: true
+          full_order: 6
+          display_in_facet: false
         relation:
           data_type: text
           facetable: false
@@ -88,6 +127,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 13
+          display_in_facet: false
         rights:
           data_type: text
           facetable: false
@@ -96,14 +139,22 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 18
+          display_in_facet: false
         subject:
           data_type: text
           facetable: true
-          indexed: true
+          indexed: true 
           mandatory: false
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: true
+          facet_order: 3
         type:
           data_type: text
           facetable: false
@@ -112,6 +163,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 7
+          display_in_facet: false
 
     ichabod:
       info:
@@ -127,6 +182,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 17
+          display_in_facet: false
         addinfotext:
           data_type: text
           facetable: false
@@ -135,6 +194,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         data_provider:
           data_type: text
           facetable: false
@@ -143,6 +205,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 16
+          display_in_facet: false
         discoverable:
           data_type: text
           facetable: false
@@ -151,6 +217,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         geometry:
           data_type: text
           facetable: false
@@ -159,6 +228,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         isbn:
           data_type: text
           facetable: false
@@ -167,6 +239,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 5
+          display_in_facet: false
         location:
           data_type: text
           facetable: false
@@ -175,6 +251,10 @@ terms:
           multiple: true
           searchable: false
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 14
+          display_in_facet: false
         repo:
           data_type: text
           facetable: false
@@ -183,6 +263,10 @@ terms:
           multiple: false
           searchable: false
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 15
+          display_in_facet: false
         resource_set:
           data_type: text
           facetable: false
@@ -191,6 +275,9 @@ terms:
           multiple: false
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         subject_spatial:
           data_type: text
           facetable: false
@@ -199,6 +286,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         subject_temporal:
           data_type: text
           facetable: false
@@ -207,6 +297,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
 
     nyucore:
       info:
@@ -224,6 +317,11 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: true
+          search_order: 6
+          display_in_full: true
+          full_order: 12
+          display_in_facet: false
         citation:
           data_type: text
           facetable: false
@@ -232,6 +330,9 @@ terms:
           multiple: true
           searchable: false
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         edition:
           data_type: text
           facetable: false
@@ -240,6 +341,9 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: false
+          display_in_facet: false
         restrictions:
           data_type: text
           facetable: false
@@ -248,6 +352,11 @@ terms:
           multiple: false
           searchable: false
           stored: true
+          display_in_search: true
+          search_order: 5
+          display_in_full: true
+          full_order: 11
+          display_in_facet: false
         series:
           data_type: text
           facetable: false
@@ -256,6 +365,10 @@ terms:
           multiple: true
           searchable: true
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 9
+          display_in_facet: false
         version:
           data_type: text
           facetable: false
@@ -264,3 +377,7 @@ terms:
           multiple: true
           searchable: false
           stored: true
+          display_in_search: false
+          display_in_full: true
+          full_order: 10
+          display_in_facet: false

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -23,6 +23,18 @@ describe CatalogController do
     it "should contain the collection field in the response" do
       expect(response_facets).to include("collection_sim")
     end
+
+    it "should generate a Blacklight configuration with facet fields in the correct order" do
+      expect(blacklight_configuration.facet_fields.keys).to eq(expected_facet_fields_order)
+    end
+
+    it "should generate a Blacklight configuration with index fields (search result item fields) in the correct order" do
+      expect(blacklight_configuration.index_fields.keys).to eq(expected_index_fields_order)
+    end
+
+    it "should generate a Blacklight configuration with show fields (canonical item view fields) in the correct order" do
+      expect(blacklight_configuration.show_fields.keys).to eq(expected_show_fields_order)
+    end
   end
 
   # Convenience

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -51,17 +51,17 @@ describe CatalogController do
         end
       end
 
-      describe "'available' show field" do
-        let(:field) { blacklight_show_field('desc_metadata__available_tesim') }
+      describe "'addinfolink' show field" do
+        let(:field) { blacklight_show_field('desc_metadata__addinfolink_tesim') }
 
         it "should have correct helper method" do
           expect(field.helper_method).to eq(:render_external_links)
         end
         it "should have correct label" do
-          expect(field.label).to eq('Online Resource')
+          expect(field.label).to eq('Additional Information')
         end
         it "should have correct text" do
-          expect(field.text).to eq('resource_text_display')
+          expect(field.text).to eq('desc_metadata__addinfotext_tesim')
         end
       end
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -24,16 +24,19 @@ describe CatalogController do
       expect(response_facets).to include("collection_sim")
     end
 
-    it "should generate a Blacklight configuration with facet fields in the correct order" do
-      expect(blacklight_configuration.facet_fields.keys).to eq(expected_facet_fields_order)
-    end
+    describe "Blacklight configuration" do
+      it "should have facet fields in the correct order" do
+        expect(blacklight_configuration.facet_fields.keys).to eq(expected_facet_fields_order)
+      end
 
-    it "should generate a Blacklight configuration with index fields (search result item fields) in the correct order" do
-      expect(blacklight_configuration.index_fields.keys).to eq(expected_index_fields_order)
-    end
+      it "should have index fields (search result item fields) in the correct order" do
+        expect(blacklight_configuration.index_fields.keys).to eq(expected_index_fields_order)
+      end
 
-    it "should generate a Blacklight configuration with show fields (canonical item view fields) in the correct order" do
-      expect(blacklight_configuration.show_fields.keys).to eq(expected_show_fields_order)
+      it "should have show fields (canonical item view fields) in the correct order" do
+        expect(blacklight_configuration.show_fields.keys).to eq(expected_show_fields_order)
+      end
+
     end
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -51,6 +51,19 @@ describe CatalogController do
         end
       end
 
+      describe "'available' show field" do
+        let(:field) { blacklight_show_field('desc_metadata__available_tesim') }
+
+        it "should have correct helper method" do
+          expect(field.helper_method).to eq(:render_external_links)
+        end
+        it "should have correct label" do
+          expect(field.label).to eq('Online Resource')
+        end
+        it "should have correct text" do
+          expect(field.text).to eq('resource_text_display')
+        end
+      end
     end
   end
 
@@ -65,6 +78,10 @@ describe CatalogController do
 
   def blacklight_index_field(field_name)
     blacklight_configuration.index_fields[field_name]
+  end
+
+  def blacklight_show_field(field_name)
+    blacklight_configuration.show_fields[field_name]
   end
 
   def expected_facet_fields_order

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -33,6 +33,68 @@ describe CatalogController do
   def blacklight_configuration
     @controller.instance_variable_get('@blacklight_config')
   end
+
+  def expected_facet_fields_order
+    [
+        'desc_metadata__type_sim',
+        'desc_metadata__creator_sim',
+        'desc_metadata__subject_sim',
+        'desc_metadata__language_sim',
+        'collection_sim'
+    ]
+  end
+
+  def expected_index_fields_order
+    [
+        'desc_metadata__title_tesim',
+        'desc_metadata__title_vern_tesim',
+        'desc_metadata__author_tesim',
+        'desc_metadata__author_vern_tesim',
+        'desc_metadata__format_ssim',
+        'desc_metadata__language_tesim',
+        'desc_metadata__published_tesim',
+        'desc_metadata__published_vern_tesim',
+        'desc_metadata__lc_callnum_tesim',
+        'desc_metadata__publisher_tesim',
+        'desc_metadata__restrictions_tesim',
+        'desc_metadata__available_tesim',
+        'desc_metadata__id_tesim'
+    ]
+  end
+
+  def expected_show_fields_order
+    [
+        'desc_metadata__title_tesim',
+        'desc_metadata__creator_tesim',
+        'desc_metadata__title_vern_tesim',
+        'desc_metadata__subtitle_tesim',
+        'desc_metadata__subtitle_vern_tesim',
+        'desc_metadata__author_tesim',
+        'desc_metadata__author_vern_tesim',
+        'desc_metadata__format_ssim',
+        'desc_metadata__url_fulltext_tsim_tesim',
+        'desc_metadata__url_suppl_tsim_tesim',
+        'desc_metadata__language_tesim',
+        'desc_metadata__published_tesim',
+        'desc_metadata__published_vern_tesim',
+        'desc_metadata__lc_callnum_tesim',
+        'desc_metadata__isbn_tesim',
+        'desc_metadata__publisher_tesim',
+        'desc_metadata__type_tesim',
+        'desc_metadata__description_tesim',
+        'desc_metadata__series_tesim',
+        'desc_metadata__version_tesim',
+        'desc_metadata__restrictions_tesim',
+        'desc_metadata__available_tesim',
+        'desc_metadata__relation_tesim',
+        'desc_metadata__location_tesim',
+        'desc_metadata__repo_tesim',
+        'desc_metadata__data_provider_tesim',
+        'desc_metadata__addinfolink_tesim',
+        'desc_metadata__rights_tesim'
+    ]
+  end
+
   def response_qf
     assigns_response["responseHeader"]["params"]["qf"]
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -37,6 +37,14 @@ describe CatalogController do
         expect(blacklight_configuration.show_fields.keys).to eq(expected_show_fields_order)
       end
 
+      describe "'type' facet field" do
+        let(:field) { blacklight_facet_field('desc_metadata__type_sim') }
+
+        it "should have correct label" do
+          expect(field.label).to eq('Format')
+        end
+      end
+
       describe "'available' index field" do
         let(:field) { blacklight_index_field('desc_metadata__available_tesim') }
 
@@ -74,6 +82,10 @@ describe CatalogController do
 
   def blacklight_configuration
     @controller.instance_variable_get('@blacklight_config')
+  end
+
+  def blacklight_facet_field(field_name)
+    blacklight_configuration.facet_fields[field_name]
   end
 
   def blacklight_index_field(field_name)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -37,6 +37,20 @@ describe CatalogController do
         expect(blacklight_configuration.show_fields.keys).to eq(expected_show_fields_order)
       end
 
+      describe "'available' index field" do
+        let(:field) { blacklight_index_field('desc_metadata__available_tesim') }
+
+        it "should have correct helper method" do
+          expect(field.helper_method).to eq(:render_external_links)
+        end
+        it "should have correct label" do
+          expect(field.label).to eq('Online Resource')
+        end
+        it "should have correct text" do
+          expect(field.text).to eq('resource_text_display')
+        end
+      end
+
     end
   end
 
@@ -47,6 +61,10 @@ describe CatalogController do
 
   def blacklight_configuration
     @controller.instance_variable_get('@blacklight_config')
+  end
+
+  def blacklight_index_field(field_name)
+    blacklight_configuration.index_fields[field_name]
   end
 
   def expected_facet_fields_order

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -30,6 +30,9 @@ describe CatalogController do
     @controller.instance_variable_get("@response")
   end
 
+  def blacklight_configuration
+    @controller.instance_variable_get('@blacklight_config')
+  end
   def response_qf
     assigns_response["responseHeader"]["params"]["qf"]
   end

--- a/spec/models/concerns/metadata_fields_spec.rb
+++ b/spec/models/concerns/metadata_fields_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe MetadataFields do
 	let(:invalid_value) { 'foo' }
 	let(:source) { 'nyucore' }
+	let(:section) { 'facet'}
 	let(:all) { MetadataFields.process_metadata_fields }
 	let(:single_source) { MetadataFields.process_metadata_fields(ns:source, multiple: false) }
+	let(:facet_section) { MetadataFields.process_metadata_fields(section:section) }
 	let(:single_source_info) { MetadataFields.get_source_info(ns:source) }
 	let(:all_sources_info) { MetadataFields.get_source_info }
 	let(:dummy_class) { Class.new { include MetadataFields } }
@@ -19,6 +21,10 @@ describe MetadataFields do
 
 		it 'raises an error if an invalid occurrence value is passed to the method' do 
 		    expect { MetadataFields.process_metadata_fields(multiple: invalid_value) }.to raise_error
+		end
+
+		it 'raises an error if an invalid occurrence value is passed to the method' do 
+		    expect { MetadataFields.process_metadata_fields(section: invalid_value) }.to raise_error
 		end
 
 		it 'returns an array if no arguments are sent' do 


### PR DESCRIPTION
@da70 @eshadatta @NYULibraries/hydra 

This is a first cut at incorporating binary "display_in_section" values, "section_order" values, and "display_labels" into the metadata_fields.yml config. I think there might be some complexity added in metadata_fields.rb that I'm not sure I like, but I'm not sure how else to deal with the ordering. I'm trying to use Esha's method patterns as a template. I'd also like to take the metadata_fields.rb out of app/models/concerns and move it to lib/??/, since I'm now utilizing it in app/controllers. I'll bring this up at the code review meeting next week, too.

I've put a first cut at consuming this into catalog controller, just for the facets section at this time, and the existing tests pass. I'd love some feedback on this before I continue working through it.

Next steps are:
* Search Results display from config
* Full display from config
* Add solr query fields to config and set there

Let me know if you have any questions or comments.

Thanks!!